### PR TITLE
add configurable cipher

### DIFF
--- a/drivers/ipmitool/bmc.go
+++ b/drivers/ipmitool/bmc.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	factory := func(ctx context.Context, opts bmc.DriverOptions) (bmc.Driver, error) {
-		s, err := NewOptions(opts.Address, opts.Username, opts.Password).Shell(ctx)
+		s, err := NewOptions(opts.Address, opts.Username, opts.Password, opts.Cipher).Shell(ctx)
 		if err != nil {
 			return nil, errors.WithMessage(err, "invalid options")
 		}

--- a/drivers/ipmitool/boot.go
+++ b/drivers/ipmitool/boot.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	factory := func(ctx context.Context, opts boot.DriverOptions) (boot.Driver, error) {
-		s, err := NewOptions(opts.Address, opts.Username, opts.Password).Shell(ctx)
+		s, err := NewOptions(opts.Address, opts.Username, opts.Password, opts.Cipher).Shell(ctx)
 		if err != nil {
 			return nil, errors.WithMessage(err, "invalid options")
 		}

--- a/drivers/ipmitool/options.go
+++ b/drivers/ipmitool/options.go
@@ -4,9 +4,12 @@
 package ipmitool
 
 import (
+	"os"
 	"os/exec"
 	"strconv"
 )
+
+var DEFAULT_CIPHER = os.Getenv("IPMITOOL_DEFAULT_CIPHER")
 
 // ExecutablePath path to ipmitool
 const ExecutablePath = "ipmitool"
@@ -18,17 +21,19 @@ type Options struct {
 	Password string
 
 	InterfaceName string
+	Cipher        int
 	Attempts      int
 	RetransSecs   int
 }
 
 // NewOptions returns an Options struct with the values provided set
-func NewOptions(addr, user, pass string) Options {
+func NewOptions(addr, user, pass string, cipher int) Options {
 	return Options{
 		Address:       addr,
 		Username:      user,
 		Password:      pass,
 		InterfaceName: "lanplus",
+		Cipher:        cipher,
 		Attempts:      1, // Give up quickly.
 		RetransSecs:   1, // Wait 1 second between retries.
 	}
@@ -51,6 +56,12 @@ func (o *Options) buildCommand(subcommand ...string) *exec.Cmd {
 
 	if o.InterfaceName != "" {
 		args = append(args, "-I", o.InterfaceName)
+	}
+
+	if o.Cipher > -1 {
+		args = append(args, "-C", strconv.Itoa(o.Cipher))
+	} else if DEFAULT_CIPHER != "" {
+		args = append(args, "-C", DEFAULT_CIPHER)
 	}
 
 	if o.Attempts > 0 {

--- a/drivers/ipmitool/power.go
+++ b/drivers/ipmitool/power.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	factory := func(ctx context.Context, opts power.DriverOptions) (power.Driver, error) {
-		s, err := NewOptions(opts.Address, opts.Username, opts.Password).Shell(ctx)
+		s, err := NewOptions(opts.Address, opts.Username, opts.Password, opts.Cipher).Shell(ctx)
 		if err != nil {
 			return nil, errors.WithMessage(err, "invalid options")
 		}

--- a/drivers/ipmitool/shell_test.go
+++ b/drivers/ipmitool/shell_test.go
@@ -19,7 +19,7 @@ func TestShell(t *testing.T) {
 		t.Skip()
 		panic("unreachable")
 	}
-	s, err := NewOptions(addr, user, pass).Shell(context.Background())
+	s, err := NewOptions(addr, user, pass, -1).Shell(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/interfaces/bmc/bmc.go
+++ b/interfaces/bmc/bmc.go
@@ -63,6 +63,7 @@ type DriverOptions struct {
 	Username string
 	Password string
 	ID       string
+	Cipher   int
 }
 
 // NewDriver instantiates a new driver by calling the registered factory function

--- a/interfaces/bmc/http.go
+++ b/interfaces/bmc/http.go
@@ -5,6 +5,7 @@ package bmc
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tinkerbell/pbnj/util"
@@ -17,6 +18,15 @@ func NewDriverFromGinContext(c *gin.Context) Driver {
 		Address:  c.Param("ip"),
 		Username: c.Request.Header.Get("X-IPMI-Username"),
 		Password: c.Request.Header.Get("X-IPMI-Password"),
+		Cipher:   -1,
+	}
+	if c.Request.Header.Get("X-IPMI-Cipher") != "" {
+		cipher, err := strconv.Atoi(c.Request.Header.Get("X-IPMI-Cipher"))
+		if err != nil {
+			_ = c.Error(err)
+			c.AbortWithStatus(http.StatusBadRequest)
+		}
+		driverOpts.Cipher = cipher
 	}
 
 	driver, err := NewDriver(c, driverType, driverOpts)

--- a/interfaces/boot/boot.go
+++ b/interfaces/boot/boot.go
@@ -49,6 +49,7 @@ type DriverOptions struct {
 	Username string
 	Password string
 	ID       string
+	Cipher   int
 }
 
 // Options contain values relevant for boot actions

--- a/interfaces/boot/http.go
+++ b/interfaces/boot/http.go
@@ -5,6 +5,7 @@ package boot
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tinkerbell/pbnj/util"
@@ -17,6 +18,15 @@ func NewDriverFromGinContext(c *gin.Context) Driver {
 		Address:  c.Param("ip"),
 		Username: c.Request.Header.Get("X-IPMI-Username"),
 		Password: c.Request.Header.Get("X-IPMI-Password"),
+		Cipher:   -1,
+	}
+	if c.Request.Header.Get("X-IPMI-Cipher") != "" {
+		cipher, err := strconv.Atoi(c.Request.Header.Get("X-IPMI-Cipher"))
+		if err != nil {
+			_ = c.Error(err)
+			c.AbortWithStatus(http.StatusBadRequest)
+		}
+		driverOpts.Cipher = cipher
 	}
 
 	driver, err := NewDriver(c, driverType, driverOpts)

--- a/interfaces/power/http.go
+++ b/interfaces/power/http.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tinkerbell/pbnj/util"
@@ -17,6 +18,15 @@ func NewDriverFromGinContext(c *gin.Context) Driver {
 		Address:  c.Param("ip"),
 		Username: c.Request.Header.Get("X-IPMI-Username"),
 		Password: c.Request.Header.Get("X-IPMI-Password"),
+		Cipher:   -1,
+	}
+	if c.Request.Header.Get("X-IPMI-Cipher") != "" {
+		cipher, err := strconv.Atoi(c.Request.Header.Get("X-IPMI-Cipher"))
+		if err != nil {
+			_ = c.Error(err)
+			c.AbortWithStatus(http.StatusBadRequest)
+		}
+		driverOpts.Cipher = cipher
 	}
 
 	driver, err := NewDriver(c, driverType, driverOpts)

--- a/interfaces/power/power.go
+++ b/interfaces/power/power.go
@@ -58,6 +58,7 @@ type DriverOptions struct {
 	Username string
 	Password string
 	ID       string
+	Cipher   int
 }
 
 // Options contain time values relevant for power actions


### PR DESCRIPTION
## Description

This change allows for a specific cipher to
be defined by default, as well as adds an api header to allow the
cipher to be defined at a per request level to support older hardware.

## Why is this needed

some older bmc models don't have support for newer ciphers that are
supported by ipmitool.