### PR TITLE
dont embed v1.Error as it contains a mutex; copy/paste its struct values

### DIFF
--- a/cmd/zaplog/zap_test.go
+++ b/cmd/zaplog/zap_test.go
@@ -1,41 +1,9 @@
 package zaplog
 
 import (
-	"bytes"
-	"io"
-	"os"
-	"sync"
 	"testing"
 )
 
 func TestRegisterLogger(t *testing.T) {
 	t.Skip("will write")
-}
-
-func captureOutput(f func()) string {
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-	}()
-	os.Stdout = writer
-	os.Stderr = writer
-	out := make(chan string)
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		var buf bytes.Buffer
-		wg.Done()
-		_, _ = io.Copy(&buf, reader)
-		out <- buf.String()
-	}()
-	wg.Wait()
-	f()
-	writer.Close()
-	return <-out
 }

--- a/pkg/oob/oob.go
+++ b/pkg/oob/oob.go
@@ -1,8 +1,6 @@
 package oob
 
-import (
-	v1 "github.com/tinkerbell/pbnj/api/v1"
-)
+import "github.com/golang/protobuf/ptypes/any"
 
 // User management methods
 type User interface {
@@ -25,5 +23,11 @@ type BMC interface {
 
 // Error for all bmc actions
 type Error struct {
-	v1.Error
+	Code int32 `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
+	// A developer-facing human-readable error message in English. It should
+	// both explain the error and offer an actionable resolution to it.
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Additional error information that the client code can use to handle
+	// the error, such as retry delay or a help link.
+	Details []*any.Any `protobuf:"bytes,3,rep,name=details,proto3" json:"details,omitempty"`
 }

--- a/server/grpcsvr/bmc/machine.go
+++ b/server/grpcsvr/bmc/machine.go
@@ -24,11 +24,9 @@ type MachineAction struct {
 func (p MachineAction) BootDevice() (string, oob.Error) {
 	var result string
 	errMsg := oob.Error{
-		Error: v1.Error{
-			Code:    0,
-			Message: "",
-			Details: nil,
-		},
+		Code:    0,
+		Message: "",
+		Details: nil,
 	}
 	l := p.Log.GetContextLogger(p.Ctx)
 	l.V(0).Info("not implemented")
@@ -46,11 +44,9 @@ func (p MachineAction) Power() (string, oob.Error) {
 	// TODO handle nil values
 	var result string
 	errMsg := oob.Error{
-		Error: v1.Error{
-			Code:    0,
-			Message: "",
-			Details: nil,
-		},
+		Code:    0,
+		Message: "",
+		Details: nil,
 	}
 
 	l.V(0).Info(fmt.Sprintf("%+v", p.PowerRequest))

--- a/server/grpcsvr/rpc/task_test.go
+++ b/server/grpcsvr/rpc/task_test.go
@@ -21,11 +21,9 @@ func TestTaskFound(t *testing.T) {
 	// create a task
 	ctx := context.Background()
 	defaultError := oob.Error{
-		Error: v1.Error{
-			Code:    0,
-			Message: "",
-			Details: nil,
-		},
+		Code:    0,
+		Message: "",
+		Details: nil,
 	}
 	l, zapLogger, _ := logr.NewPacketLogr()
 	logger := zaplog.RegisterLogger(l)

--- a/server/grpcsvr/taskrunner/taskrunner_test.go
+++ b/server/grpcsvr/taskrunner/taskrunner_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/packethost/pkg/log/logr"
 	"github.com/philippgille/gokv"
 	"github.com/philippgille/gokv/freecache"
-	v1 "github.com/tinkerbell/pbnj/api/v1"
 	"github.com/tinkerbell/pbnj/cmd/zaplog"
 	"github.com/tinkerbell/pbnj/pkg/oob"
 	"github.com/tinkerbell/pbnj/server/grpcsvr/persistence"
@@ -18,11 +17,9 @@ import (
 func TestRoundTrip(t *testing.T) {
 	description := "test task"
 	defaultError := oob.Error{
-		Error: v1.Error{
-			Code:    0,
-			Message: "",
-			Details: nil,
-		},
+		Code:    0,
+		Message: "",
+		Details: nil,
 	}
 	ctx := context.Background()
 	f := freecache.NewStore(freecache.DefaultOptions)


### PR DESCRIPTION
Signed-off-by: Jacob Weinstock <jakobweinstock@gmail.com>

## Description

don't embedding v1.Error as it contains a mutex. 

## Why is this needed

fix failed builds (go vet; golangci-lint)

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
