### PR TITLE
github actions golangci-lint fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,16 +14,16 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.14.6'
+        go-version: '1.15.5'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.32
+        args: -v -D errcheck
     - name: go fmt
       run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
     - name: go vet
       run: go vet ./...
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
-      with:
-        version: v1.30
-        args: -v -D errcheck
     - name: go test
       run: go test -v ./...    
     - name: go test coverage
@@ -58,6 +58,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io
       uses: docker/login-action@v1
+      if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
## Description

Fix golangci-lint GitHub actions error. I've tried to reproduce this error locally with [act](https://github.com/nektos/act) but I'm not able to. Testing now directly with GitHub.  Upgrading to golangci-lint v2 and reordering it to run first. Root cause seems to be here: https://github.com/golangci/golangci-lint-action/issues/23#issuecomment-647177770 
```bash
Error: /bin/tar: ../../../go/pkg/mod/goa.design/goa@v2.2.4+incompatible/http/mux.go: Cannot open: File exists
.
.
.
Error: /bin/tar: ../../../go/pkg/mod/golang.org/x/text@v0.3.4/width/runes_test.go: Cannot open: File exists
```

## Why is this needed

in order to get clean GitHub action runs

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
