### PR TITLE
add healthcheck endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM golang:1.15 as builder
 LABEL maintainers="https://tinkerbell.org/community/slack/"
 
+ARG GRPC_HEALTH_PROBE_VERSION=v0.3.4
+
+RUN wget -O/tmp/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+		chmod +x /tmp/grpc_health_probe
+
 WORKDIR /code
 COPY go.mod go.sum /code/
 RUN go mod download
@@ -14,6 +19,7 @@ EXPOSE 9090
 
 COPY scripts/etc-passwd /etc/passwd
 COPY --from=builder /code/bin/pbnj-linux-amd64 /pbnj-linux-amd64
+COPY --from=builder /tmp/grpc_health_probe /bin/grpc_health_probe
 
 ENTRYPOINT ["/pbnj-linux-amd64"]
 CMD ["server"]

--- a/cmd/pbnj/server.go
+++ b/cmd/pbnj/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -12,8 +11,8 @@ import (
 	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/packethost/pkg/log/logr"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
+	"github.com/tinkerbell/pbnj/pkg/http"
 	"github.com/tinkerbell/pbnj/pkg/zaplog"
 	"github.com/tinkerbell/pbnj/server/grpcsvr"
 	"goa.design/goa/grpc/middleware"
@@ -63,8 +62,9 @@ var (
 			)
 
 			go func() {
-				http.Handle("/metrics", promhttp.Handler())
-				err := http.ListenAndServe(metricsAddr, nil)
+				http.WithLogger(logger)
+				http.RegisterHandlers()
+				err := http.ListenAndServe(metricsAddr)
 				if err != nil {
 					logger.Error(err, "failed to serve http")
 					os.Exit(1)

--- a/cmd/pbnj/server.go
+++ b/cmd/pbnj/server.go
@@ -61,17 +61,10 @@ var (
 				),
 			)
 
-			go func() {
-				http.WithLogger(logger)
-				http.RegisterHandlers()
-				err := http.ListenAndServe(metricsAddr)
-				if err != nil {
-					logger.Error(err, "failed to serve http")
-					os.Exit(1)
-				}
-			}()
+			httpServer := http.NewHTTPServer(metricsAddr)
+			httpServer.WithLogger(logger)
 
-			if err := grpcsvr.RunServer(ctx, zaplog.RegisterLogger(logger), grpcServer, port); err != nil {
+			if err := grpcsvr.RunServer(ctx, zaplog.RegisterLogger(logger), grpcServer, port, httpServer); err != nil {
 				logger.Error(err, "error running server")
 				os.Exit(1)
 			}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,25 @@
+package healthcheck
+
+import (
+	"context"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type HealthChecker struct{}
+
+func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+	return server.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	})
+}
+
+func NewHealthChecker() *HealthChecker {
+	return &HealthChecker{}
+}

--- a/pkg/http/handlers.go
+++ b/pkg/http/handlers.go
@@ -1,0 +1,44 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func runningTasks() int {
+	if taskRunner == nil {
+		return 0
+	}
+	return taskRunner.ActiveWorkers()
+}
+
+func totalTasks() int {
+	if taskRunner == nil {
+		return 0
+	}
+	return taskRunner.TotalWorkers()
+}
+
+func handleHealthcheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, err := w.Write([]byte(fmt.Sprintf(`{"running_tasks": %d, "total_tasks": %d}`, runningTasks(), totalTasks())))
+	if err != nil {
+		logger.Error(err, " Failed to write healthcheck")
+	}
+}
+
+func handleReady(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, err := w.Write([]byte(`{"ready": true}`))
+	if err != nil {
+		logger.Error(err, " Failed to write ready")
+	}
+}
+
+func handleLive(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, err := w.Write([]byte(`{"live": true}`))
+	if err != nil {
+		logger.Error(err, " Failed to write live")
+	}
+}

--- a/pkg/http/handlers.go
+++ b/pkg/http/handlers.go
@@ -5,40 +5,40 @@ import (
 	"net/http"
 )
 
-func runningTasks() int {
-	if taskRunner == nil {
+func (h *HTTPServer) runningTasks() int {
+	if h.taskRunner == nil {
 		return 0
 	}
-	return taskRunner.ActiveWorkers()
+	return h.taskRunner.ActiveWorkers()
 }
 
-func totalTasks() int {
-	if taskRunner == nil {
+func (h *HTTPServer) totalTasks() int {
+	if h.taskRunner == nil {
 		return 0
 	}
-	return taskRunner.TotalWorkers()
+	return h.taskRunner.TotalWorkers()
 }
 
-func handleHealthcheck(w http.ResponseWriter, r *http.Request) {
+func (h *HTTPServer) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_, err := w.Write([]byte(fmt.Sprintf(`{"running_tasks": %d, "total_tasks": %d}`, runningTasks(), totalTasks())))
+	_, err := w.Write([]byte(fmt.Sprintf(`{"running_tasks": %d, "total_tasks": %d}`, h.runningTasks(), h.totalTasks())))
 	if err != nil {
-		logger.Error(err, " Failed to write healthcheck")
+		h.logger.Error(err, " Failed to write healthcheck")
 	}
 }
 
-func handleReady(w http.ResponseWriter, r *http.Request) {
+func (h *HTTPServer) handleReady(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write([]byte(`{"ready": true}`))
 	if err != nil {
-		logger.Error(err, " Failed to write ready")
+		h.logger.Error(err, " Failed to write ready")
 	}
 }
 
-func handleLive(w http.ResponseWriter, r *http.Request) {
+func (h *HTTPServer) handleLive(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write([]byte(`{"live": true}`))
 	if err != nil {
-		logger.Error(err, " Failed to write live")
+		h.logger.Error(err, " Failed to write live")
 	}
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,0 +1,33 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/tinkerbell/pbnj/server/grpcsvr/taskrunner"
+)
+
+var (
+	logger     logr.Logger
+	taskRunner *taskrunner.Runner
+)
+
+func WithLogger(log logr.Logger) {
+	logger = log
+}
+
+func WithTaskRunner(runner *taskrunner.Runner) {
+	taskRunner = runner
+}
+
+func RegisterHandlers() {
+	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/healthcheck", handleHealthcheck)
+	http.HandleFunc("/_/ready", handleReady)
+	http.HandleFunc("/_/live", handleLive)
+}
+
+func ListenAndServe(addr string) error {
+	return http.ListenAndServe(addr, nil)
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -8,26 +8,39 @@ import (
 	"github.com/tinkerbell/pbnj/server/grpcsvr/taskrunner"
 )
 
-var (
+type HTTPServer struct {
+	address    string
 	logger     logr.Logger
+	mux        *http.ServeMux
 	taskRunner *taskrunner.Runner
-)
-
-func WithLogger(log logr.Logger) {
-	logger = log
 }
 
-func WithTaskRunner(runner *taskrunner.Runner) {
-	taskRunner = runner
+func (h *HTTPServer) WithLogger(log logr.Logger) *HTTPServer {
+	h.logger = log
+	return h
 }
 
-func RegisterHandlers() {
-	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/healthcheck", handleHealthcheck)
-	http.HandleFunc("/_/ready", handleReady)
-	http.HandleFunc("/_/live", handleLive)
+func (h *HTTPServer) WithTaskRunner(runner *taskrunner.Runner) *HTTPServer {
+	h.taskRunner = runner
+	return h
 }
 
-func ListenAndServe(addr string) error {
-	return http.ListenAndServe(addr, nil)
+func (h *HTTPServer) init() {
+	h.mux = http.NewServeMux()
+	h.mux.Handle("/metrics", promhttp.Handler())
+	h.mux.HandleFunc("/healthcheck", h.handleHealthcheck)
+	h.mux.HandleFunc("/_/ready", h.handleReady)
+	h.mux.HandleFunc("/_/live", h.handleLive)
+}
+
+func (h *HTTPServer) Run() error {
+	return http.ListenAndServe(h.address, h.mux)
+}
+
+func NewHTTPServer(addr string) *HTTPServer {
+	server := &HTTPServer{
+		address: addr,
+	}
+	server.init()
+	return server
 }

--- a/server/grpcsvr/server.go
+++ b/server/grpcsvr/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/philippgille/gokv"
 	"github.com/philippgille/gokv/freecache"
 	v1 "github.com/tinkerbell/pbnj/api/v1"
+	"github.com/tinkerbell/pbnj/pkg/healthcheck"
 	"github.com/tinkerbell/pbnj/pkg/http"
 	"github.com/tinkerbell/pbnj/pkg/logging"
 	"github.com/tinkerbell/pbnj/pkg/repository"
@@ -17,6 +18,7 @@ import (
 	"github.com/tinkerbell/pbnj/server/grpcsvr/rpc"
 	"github.com/tinkerbell/pbnj/server/grpcsvr/taskrunner"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // Server options
@@ -80,6 +82,9 @@ func RunServer(ctx context.Context, log logging.Logger, grpcServer *grpc.Server,
 	v1.RegisterTaskServer(grpcServer, &ts)
 
 	grpc_prometheus.Register(grpcServer)
+
+	hc := healthcheck.NewHealthChecker()
+	grpc_health_v1.RegisterHealthServer(grpcServer, hc)
 
 	listen, err := net.Listen("tcp", ":"+port)
 	if err != nil {

--- a/server/grpcsvr/server.go
+++ b/server/grpcsvr/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/philippgille/gokv"
 	"github.com/philippgille/gokv/freecache"
 	v1 "github.com/tinkerbell/pbnj/api/v1"
+	"github.com/tinkerbell/pbnj/pkg/http"
 	"github.com/tinkerbell/pbnj/pkg/logging"
 	"github.com/tinkerbell/pbnj/pkg/repository"
 	"github.com/tinkerbell/pbnj/server/grpcsvr/persistence"
@@ -57,6 +58,8 @@ func RunServer(ctx context.Context, log logging.Logger, grpcServer *grpc.Server,
 		Ctx:        ctx,
 		Log:        log,
 	}
+
+	http.WithTaskRunner(taskRunner)
 
 	ms := rpc.MachineService{
 		Log:        log,


### PR DESCRIPTION
healthcheck endpoint includes number of running tasks and total tasks executed.

In addition to the healthcheck endpoint, `/_/ready` and `/_/live` have also been
implemented for readiness and liveness probes to hit. Currently they always
return a 200 status. In the future we may be able to make the more useful.