### PR TITLE
Create container images on pbnj.next but dont update latest image tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io
       uses: docker/login-action@v1
-      if: ${{ startsWith(github.ref, 'refs/heads/master') }} ||
-          ${{ startsWith(github.ref, 'refs/heads/pbnj.next') }}
+      if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -70,6 +69,17 @@ jobs:
         context: ./
         file: ./Dockerfile
         cache-from: type=registry,ref=quay.io/tinkerbell/pbnj:latest
-        push: ${{ startsWith(github.ref, 'refs/heads/master') }} ||
-              ${{ startsWith(github.ref, 'refs/heads/pbnj.next') }}
+        push: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        tags: ${{ steps.docker-image-tag.outputs.tags }}
+    - name: Docker Image Tag for Sha
+      id: docker-image-tag
+      run: |
+        echo ::set-output name=tags::quay.io/tinkerbell/pbnj:sha-${GITHUB_SHA::8}
+    - name: quay.io/tinkerbell/pbnj image for pbnj.next
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        cache-from: type=registry,ref=quay.io/tinkerbell/pbnj:latest
+        push: ${{ startsWith(github.ref, 'refs/heads/pbnj.next') }}
         tags: ${{ steps.docker-image-tag.outputs.tags }}


### PR DESCRIPTION
## Description

Create container images on pbnj.next but dont update latest image tag

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
