### PR TITLE
Decrease BMC actions timeout

### DIFF
--- a/server/grpcsvr/rpc/bmc.go
+++ b/server/grpcsvr/rpc/bmc.go
@@ -14,7 +14,7 @@ import (
 // before it is cancelled. This is for use in a
 // TaskRunner.Execute function that runs all BMC
 // interactions in the background.
-const defaultTimeout = 5 * time.Minute
+const defaultTimeout = 15 * time.Second
 
 // BmcService for doing BMC actions
 type BmcService struct {


### PR DESCRIPTION
## Description

The current 5-minute timeout creates an undesired user experience as the user has to wait up to 5 minutes for a task to finish
and the task status to be updated as complete. Changing the timeout to maybe lower than it should be but this will improve the user experience, for now.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
