### PR TITLE
Replace Drone badge with GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,15 +15,15 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.14.6'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.30
+        args: -v -D errcheck
     - name: go fmt
       run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
     - name: go vet
       run: go vet ./...
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
-      with:
-        version: v1.30
-        args: -v -D errcheck
     - name: go test
       run: go test -v ./...    
     - name: go test coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PBNJ
-[![Build Status](https://cloud.drone.io/api/badges/tinkerbell/pbnj/status.svg)](https://cloud.drone.io/tinkerbell/pbnj)
+
+[![Build Status](https://github.com/tinkerbell/pbnj/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/pbnj/workflows/For%20each%20commit%20and%20PR/badge.svg)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 This service handles BMC interactions.


### PR DESCRIPTION
These drone CI banners are no longer used

