### PR TITLE
Link to action runs, not the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PBNJ
 
-[![Build Status](https://github.com/tinkerbell/pbnj/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/pbnj/workflows/For%20each%20commit%20and%20PR/badge.svg)
+[![Build Status](https://github.com/tinkerbell/pbnj/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/pbnj/actions?query=workflow%3A%22For+each+commit+and+PR%22+branch%3Amaster)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 
 This service handles BMC interactions.


### PR DESCRIPTION
No need to link to the badge itself, it is already being displayed.
Instead it makes more sense to see all the actual builds.