### PR TITLE
Add bmc ip to all log lines

### DIFF
--- a/cmd/pbnj/server.go
+++ b/cmd/pbnj/server.go
@@ -59,6 +59,7 @@ var (
 					middleware.UnaryRequestID(middleware.UseXRequestIDMetadataOption(true), middleware.XRequestMetadataLimitOption(512)),
 					zaplog.UnaryLogRequestID(zlog, requestIDKey, requestIDLogKey),
 					grpc_zap.UnaryServerInterceptor(zlog),
+					zaplog.UnaryLogBMCIP(),
 					grpc_validator.UnaryServerInterceptor(),
 				),
 			)


### PR DESCRIPTION
## Description

Add the BMC IP to all logs in order to provide better search/grouping in the logs for requests.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
