### PR TITLE
Use release version of ipmitool:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.8
 LABEL maintainers="https://tinkerbell.org/community/slack/"
 
 ARG IPMITOOL_REPO=https://github.com/ipmitool/ipmitool.git
-ARG IPMITOOL_COMMIT=c3939dac2c060651361fc71516806f9ab8c38901
+ARG IPMITOOL_COMMIT=b5ce925744851b58193ad3ee18957ce88f6efc26
 ARG GRPC_HEALTH_PROBE_VERSION=v0.3.4
 
 WORKDIR /tmp


### PR DESCRIPTION
## Description

Use the 1.18 release version of `ipmitool`. Fixes some "no matching cipher suite" issues.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
