### PR TITLE
Fix viper cant handle dashes:

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -102,7 +102,7 @@ var (
 
 func init() {
 	serverCmd.PersistentFlags().StringVar(&port, "port", "50051", "grpc server port")
-	serverCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-listen-addr", ":8080", "metrics server listen address")
+	serverCmd.PersistentFlags().StringVar(&metricsAddr, "metricsListenAddr", ":8080", "metrics server listen address")
 	serverCmd.PersistentFlags().BoolVar(&enableHTTP, "enableHTTP", false, "enable the HTTP server")
 	serverCmd.PersistentFlags().BoolVar(&enableAuthz, "enableAuthz", false, "enable Authz middleware. Configure with configuration file details")
 	serverCmd.PersistentFlags().StringVar(&hsKey, "hsKey", "", "HS key")


### PR DESCRIPTION
## Description

Viper library has a bug where dashes in an
env var just dont work. https://github.com/spf13/viper/issues/1019
Changing metric port setting to not use dashes.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
