### PR TITLE
Update gRPC error 

### DIFF
--- a/server/grpcsvr/rpc/task.go
+++ b/server/grpcsvr/rpc/task.go
@@ -6,6 +6,8 @@ import (
 	v1 "github.com/tinkerbell/pbnj/api/v1"
 	"github.com/tinkerbell/pbnj/pkg/logging"
 	"github.com/tinkerbell/pbnj/pkg/task"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TaskService for retrieving task details
@@ -22,7 +24,7 @@ func (t *TaskService) Status(ctx context.Context, in *v1.StatusRequest) (*v1.Sta
 
 	record, err := t.TaskRunner.Status(ctx, in.TaskId)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 	var errMsg *v1.Error
 	if record.Error != nil {

--- a/server/grpcsvr/rpc/task_test.go
+++ b/server/grpcsvr/rpc/task_test.go
@@ -71,7 +71,7 @@ func TestRecordNotFound(t *testing.T) {
 		{
 			name:        "record of task not found",
 			req:         &v1.StatusRequest{TaskId: "123"},
-			message:     "record id not found: 123",
+			message:     "rpc error: code = NotFound desc = record id not found: 123",
 			expectedErr: true,
 		},
 	}


### PR DESCRIPTION
## Description

Not returning an actual gRPC error causes the log line thats returned for each call to an RPC to be of error level and contain a stacktrace. Using an actual gRPC error in the return keeps the log level at info and just returns the contents of the error. Better user experience when searching and filtering logs.

Before:

```
{
    "level": "error",
    "ts": 1615309334.3296337,
    "caller": "zap/options.go:203",
    "msg": "finished unary call with code Unknown",
    "service": "github.com/tinkerbell/pbnj",
    "grpc.start_time": "2021-03-09T17:02:14Z",
    "system": "grpc",
    "span.kind": "server",
    "grpc.service": "github.com.tinkerbell.pbnj.api.v1.Task",
    "grpc.method": "Status",
    "peer.address": "192.168.0.195:48462",
    "requestID": "c5da62f4f8acc7c1e3423e793d127eee",
    "error": "record id not found: JUSTTESTING",
    "errorVerbose": "record id not found: JUSTTESTING\ngithub.com/tinkerbell/pbnj/server/grpcsvr/persistence.(*GoKV).Get\n\tgithub.com/tinkerbell/pbnj/server/grpcsvr/persistence/repo.go:32\ngithub.com/tinkerbell/pbnj/server/grpcsvr/taskrunner.(*Runner).Status\n\tgithub.com/tinkerbell/pbnj/server/grpcsvr/taskrunner/taskrunner.go:142\ngithub.com/tinkerbell/pbnj/server/grpcsvr/rpc.(*TaskService).Status\n\tgithub.com/tinkerbell/pbnj/server/grpcsvr/rpc/task.go:23\ngithub.com/tinkerbell/pbnj/api/v1._Task_Status_Handler.func1\n\tgithub.com/tinkerbell/pbnj/api/v1/task_grpc.pb.go:82\ngithub.com/grpc-ecosystem/go-grpc-middleware/validator.UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/validator/validator.go:28\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/tinkerbell/pbnj/pkg/zaplog.UnaryLogBMCIP.func1.1\n\tgithub.com/tinkerbell/pbnj/pkg/zaplog/middleware.go:49\nruntime.gopanic\n\truntime/panic.go:969\nreflect.valueInterface\n\treflect/value.go:1021\nreflect.Value.Interface\n\treflect/value.go:1016\ngithub.com/tinkerbell/pbnj/pkg/zaplog.UnaryLogBMCIP.func1\n\tgithub.com/tinkerbell/pbnj/pkg/zaplog/middleware.go:54\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-middleware/logging/zap.UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/logging/zap/server_interceptors.go:31\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/tinkerbell/pbnj/pkg/zaplog.UnaryLogRequestID.func1\n\tgithub.com/tinkerbell/pbnj/pkg/zaplog/middleware.go:37\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngoa.design/goa/grpc/middleware.UnaryRequestID.func1\n\tgoa.design/goa@v2.2.5+incompatible/grpc/middleware/requestid.go:34\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-middleware/tags.UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/tags/interceptors.go:23\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/tinkerbell/pbnj/cmd.glob..func3.1\n\tgithub.com/tinkerbell/pbnj/cmd/server.go:64\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:34\ngithub.com/tinkerbell/pbnj/api/v1._Task_Status_Handler\n\tgithub.com/tinkerbell/pbnj/api/v1/task_grpc.pb.go:84\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\tgoogle.golang.org/grpc@v1.35.0/server.go:1217\ngoogle.golang.org/grpc.(*Server).handleStream\n\tgoogle.golang.org/grpc@v1.35.0/server.go:1540\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\tgoogle.golang.org/grpc@v1.35.0/server.go:878\nruntime.goexit\n\truntime/asm_amd64.s:1374",
    "grpc.code": "Unknown",
    "grpc.time_ms": 0.1080000028014183,
    "stacktrace": "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap.DefaultMessageProducer\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/logging/zap/options.go:203\ngithub.com/grpc-ecosystem/go-grpc-middleware/logging/zap.UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/logging/zap/server_interceptors.go:39\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/tinkerbell/pbnj/pkg/zaplog.UnaryLogRequestID.func1\n\tgithub.com/tinkerbell/pbnj/pkg/zaplog/middleware.go:37\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngoa.design/goa/grpc/middleware.UnaryRequestID.func1\n\tgoa.design/goa@v2.2.5+incompatible/grpc/middleware/requestid.go:34\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-middleware/tags.UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/tags/interceptors.go:23\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/tinkerbell/pbnj/cmd.glob..func3.1\n\tgithub.com/tinkerbell/pbnj/cmd/server.go:64\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1\n\tgithub.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:25\ngithub.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1\n\tgithub.com/grpc-ecosystem/go-grpc-middleware@v1.2.2/chain.go:34\ngithub.com/tinkerbell/pbnj/api/v1._Task_Status_Handler\n\tgithub.com/tinkerbell/pbnj/api/v1/task_grpc.pb.go:84\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\tgoogle.golang.org/grpc@v1.35.0/server.go:1217\ngoogle.golang.org/grpc.(*Server).handleStream\n\tgoogle.golang.org/grpc@v1.35.0/server.go:1540\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\tgoogle.golang.org/grpc@v1.35.0/server.go:878"
}
```
After:

```
{
  "level": "info",
  "ts": 1615612730.038713,
  "caller": "rpc/task.go:23",
  "msg": "start Status request",
  "service": "github.com/tinkerbell/pbnj",
  "grpc.start_time": "2021-03-12T22:18:50-07:00",
  "system": "grpc",
  "span.kind": "server",
  "grpc.service": "github.com.tinkerbell.pbnj.api.v1.Task",
  "grpc.method": "Status",
  "peer.address": "127.0.0.1:50573",
  "requestID": "AWzoM6xR",
  "taskID": "asdf"
}
```

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
