### PR TITLE
Add configurable timeout for BMC calls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
         args: -v -D errcheck --timeout=2m
     - name: go fmt
       run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
+    - name: prepare go mod
+      run: go mod tidy
     - name: go vet
       run: go vet ./...
     - name: go test

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	jwt "github.com/cristalhq/jwt/v3"
 	jwt_helper "github.com/dgrijalva/jwt-go"
@@ -37,6 +38,8 @@ var (
 	enableAuthz bool
 	hsKey       string
 	rsPubKey    string
+	// bmcTimeout is how long a BMC call/interaction is allow to run before it is cancelled.
+	bmcTimeout time.Duration
 	// serverCmd represents the server command
 	serverCmd = &cobra.Command{
 		Use:   "server",
@@ -92,7 +95,7 @@ var (
 				go httpsvr.RunHTTPServer()
 			}
 
-			if err := grpcsvr.RunServer(ctx, zaplog.RegisterLogger(logger), grpcServer, port, httpServer); err != nil {
+			if err := grpcsvr.RunServer(ctx, zaplog.RegisterLogger(logger), grpcServer, port, httpServer, grpcsvr.WithBmcTimeout(bmcTimeout)); err != nil {
 				logger.Error(err, "error running server")
 				os.Exit(1)
 			}
@@ -107,6 +110,7 @@ func init() {
 	serverCmd.PersistentFlags().BoolVar(&enableAuthz, "enableAuthz", false, "enable Authz middleware. Configure with configuration file details")
 	serverCmd.PersistentFlags().StringVar(&hsKey, "hsKey", "", "HS key")
 	serverCmd.PersistentFlags().StringVar(&rsPubKey, "rsPubKey", "", "RS public key")
+	serverCmd.PersistentFlags().DurationVar(&bmcTimeout, "bmcTimeout", (15 * time.Second), "Timeout for BMC calls")
 	rootCmd.AddCommand(serverCmd)
 }
 

--- a/server/grpcsvr/rpc/bmc.go
+++ b/server/grpcsvr/rpc/bmc.go
@@ -12,15 +12,14 @@ import (
 	"github.com/tinkerbell/pbnj/server/grpcsvr/oob/bmc"
 )
 
-// defaultTimeout is how long a task should be run
-// before it is cancelled. This is for use in a
-// TaskRunner.Execute function that runs all BMC
-// interactions in the background.
-const defaultTimeout = 15 * time.Second
-
 // BmcService for doing BMC actions
 type BmcService struct {
-	Log        logging.Logger
+	Log logging.Logger
+	// Timeout is how long a task should be run
+	// before it is cancelled. This is for use in a
+	// TaskRunner.Execute function that runs all BMC
+	// interactions in the background.
+	Timeout    time.Duration
 	TaskRunner task.Task
 	v1.UnimplementedBMCServer
 }
@@ -52,7 +51,7 @@ func (b *BmcService) Reset(ctx context.Context, in *v1.ResetRequest) (*v1.ResetR
 		if err != nil {
 			return "", err
 		}
-		taskCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+		taskCtx, cancel := context.WithTimeout(ctx, b.Timeout)
 		// cant defer this cancel because it cancels the context before the func is run
 		// cant have cancel be _ because go vet complains.
 		// TODO(jacobweinstock): maybe move this context withTimeout into the TaskRunner.Execute function
@@ -88,7 +87,7 @@ func (b *BmcService) CreateUser(ctx context.Context, in *v1.CreateUserRequest) (
 		if err != nil {
 			return "", err
 		}
-		taskCtx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		taskCtx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		_ = cancel
 		return "", task.CreateUser(taskCtx)
 	}
@@ -121,7 +120,7 @@ func (b *BmcService) UpdateUser(ctx context.Context, in *v1.UpdateUserRequest) (
 		if err != nil {
 			return "", err
 		}
-		taskCtx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		taskCtx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		_ = cancel
 		return "", task.UpdateUser(taskCtx)
 	}
@@ -152,7 +151,7 @@ func (b *BmcService) DeleteUser(ctx context.Context, in *v1.DeleteUserRequest) (
 		if err != nil {
 			return "", err
 		}
-		taskCtx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		taskCtx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		_ = cancel
 		return "", task.DeleteUser(taskCtx)
 	}


### PR DESCRIPTION
## Description

This allows end-users to increase or decrease the timeout at runtime.
BMCs can be unpredictable, being able to tune the timeout of BMC calls is very helpful.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] added unit or e2e tests
- [X] provided instructions on how to upgrade
