### PR TITLE
Key gRPC error off record.Error.Message:

### DIFF
--- a/server/grpcsvr/rpc/task.go
+++ b/server/grpcsvr/rpc/task.go
@@ -26,6 +26,10 @@ func (t *TaskService) Status(ctx context.Context, in *v1.StatusRequest) (*v1.Sta
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
+	var c codes.Code = codes.OK
+	if record.Error.Message != "" {
+		c = codes.Unknown
+	}
 
 	return &v1.StatusResponse{
 		Id:          record.Id,
@@ -35,5 +39,5 @@ func (t *TaskService) Status(ctx context.Context, in *v1.StatusRequest) (*v1.Sta
 		Result:      record.Result,
 		Complete:    record.Complete,
 		Messages:    record.Messages,
-	}, status.Error(codes.Code(record.Error.Code), record.Error.Message)
+	}, status.Error(c, record.Error.Message)
 }


### PR DESCRIPTION
## Description

Keying the gRPC error off the code is problematic because not all BMC calls return a code.
All BMC calls that do fail will have a message so we use that.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
