### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This service handles BMC interactions.
 - setting BMC network source
 
 PBnJ started out as an HTTP server, listening by default on port 9090.
-This server is scheduled for deprecation and not enabled by default.
+This HTTP server (not the gRPC server) is scheduled for deprecation and not enabled by default.
 To enable the HTTP server, you must run PBnJ with `pbnj server --enableHTTP` or `PBNJ_ENABLEHTTP=true pbnj server`.
 The gRPC PBnJ server listens by default on port 50051.
 This can be started with `pbnj server`.


### PR DESCRIPTION
## Description

clarify that only the HTTP server is being deprecated, not the gRPC server.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
