### PR TITLE
Add 'lint-install' rules, de-lint codebase

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,19 +15,14 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.15.5'
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.32
-        args: -v -D errcheck --timeout=2m
     - name: go fmt
       run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
     - name: prepare go mod
       run: go mod tidy
-    - name: go vet
-      run: go vet ./...
     - name: go test
       run: go test -v ./...    
+    - name: lint
+      run: make lint
     - name: go test coverage
       run: go test -coverprofile=coverage.txt ./...
     - name: upload codecov

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,199 @@
+# NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
+linters-settings:
+  cyclop:
+    # NOTE: This is a very high transitional threshold
+    max-complexity: 37
+    package-average: 34.0
+    skip-tests: true
+
+  gocognit:
+    # NOTE: This is a very high transitional threshold
+    min-complexity: 98
+
+  dupl:
+    threshold: 200
+
+  goconst:
+    min-len: 4
+    min-occurrences: 5
+    ignore-tests: true
+
+  errorlint:
+    # these are still common in Go: for instance, exit errors.
+    asserts: false
+
+  exhaustive:
+    default-signifies-exhaustive: true
+
+  nestif:
+    min-complexity: 8
+
+  nolintlint:
+      require-explanation: true
+      allow-unused: false
+      require-specific: true
+
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: confusing-naming
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: dot-imports
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: identical-branches
+      - name: if-return
+      - name: import-shadowing
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: struct-tag
+      - name: time-naming
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+      - name: unconditional-recursion
+      - name: waitgroup-by-value
+
+  staticcheck:
+    go: "1.16"
+
+  unused:
+    go: "1.16"
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - cyclop
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # errname is only available in golangci-lint v1.42.0+ - wait until v1.43 is available to settle
+    #- errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    - predeclared
+    # disabling for the initial iteration of the linting tool
+    #- promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+
+  # Disabled linters, due to being misaligned with Go practices
+  # - exhaustivestruct
+  # - gochecknoglobals
+  # - gochecknoinits
+  # - goconst
+  # - godox
+  # - goerr113
+  # - gomnd
+  # - lll
+  # - nlreturn
+  # - testpackage
+  # - wsl
+
+  # Disabled linters, due to not being relevant to our code base:
+  # - maligned
+  # - prealloc "For most programs usage of prealloc will be a premature optimization."
+
+  # Disabled linters due to bad error messages or bugs
+  # - gofumpt
+  # - gosec
+  # - tagliatelle
+
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+
+    - path: cmd.*
+      linters:
+        - noctx
+
+    - path: main\.go
+      linters:
+        - noctx
+
+    - path: cmd.*
+      text: "deep-exit"
+
+    - path: main\.go
+      text: "deep-exit"
+
+    # This check is of questionable value
+    - linters:
+        - tparallel
+      text: "call t.Parallel on the top level as well as its subtests"
+
+  # Don't hide lint issues just because there are many of them
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ ARG IPMITOOL_COMMIT=b5ce925744851b58193ad3ee18957ce88f6efc26
 ARG GRPC_HEALTH_PROBE_VERSION=v0.3.4
 
 WORKDIR /tmp
-RUN apk add --update --upgrade --no-cache --virtual \
-        build-deps=0 \
+RUN apk add --update --upgrade --no-cache --virtual build-deps \
         alpine-sdk=1.0-r0 \
         autoconf=2.69-r2 \
         automake=1.16.1-r0 \
@@ -25,12 +24,11 @@ RUN apk add --update --upgrade --no-cache --virtual \
         ncurses-dev=6.1_p20180818-r1 \
         openssl-dev=1.0.2u-r0 \
         readline-dev=7.0.003-r0 \
-        pbnj-runtime-deps=20210828.182213 \
+    && apk add --update --upgrade --no-cache --virtual run-deps \
 	    ca-certificates=20191127-r2 \
         libcrypto1.0=1.0.2u-r0 \
         musl=1.1.19-r11 \
         readline=7.0.003-r0 \
-    && apk del build-deps \
     && git clone -b master ${IPMITOOL_REPO}
 
 WORKDIR /tmp/ipmitool
@@ -44,7 +42,8 @@ RUN git checkout ${IPMITOOL_COMMIT} \
         --enable-intf-lanplus \
         --enable-intf-open \
     && make \
-    && make install
+    && make install \
+    && apk del build-deps
 
 WORKDIR /tmp
 RUN rm -rf /tmp/ipmitool \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,42 +15,41 @@ ARG IPMITOOL_COMMIT=b5ce925744851b58193ad3ee18957ce88f6efc26
 ARG GRPC_HEALTH_PROBE_VERSION=v0.3.4
 
 WORKDIR /tmp
-RUN apk add --update --upgrade --no-cache --virtual build-deps \
-        alpine-sdk \
-        autoconf \
-        automake \
-        git \
-        libtool \
-        ncurses-dev \
-        openssl-dev \
-        readline-dev \
-        && \
-    apk add --update --upgrade --no-cache --virtual pbnj-runtime-deps \
-	ca-certificates \
-        libcrypto1.0 \
-        musl \
-        readline \
-        && \
-    git clone -b master ${IPMITOOL_REPO} && \
-    cd ipmitool && \
-    git checkout ${IPMITOOL_COMMIT} && \
-    ./bootstrap && \
-    ./configure \
+RUN apk add --update --upgrade --no-cache --virtual \
+        build-deps=0 \
+        alpine-sdk=1.0-r0 \
+        autoconf=2.69-r2 \
+        automake=1.16.1-r0 \
+        git=2.18.4-r0 \
+        libtool=2.4.6-r5 \
+        ncurses-dev=6.1_p20180818-r1 \
+        openssl-dev=1.0.2u-r0 \
+        readline-dev=7.0.003-r0 \
+        pbnj-runtime-deps=20210828.182213 \
+	    ca-certificates=20191127-r2 \
+        libcrypto1.0=1.0.2u-r0 \
+        musl=1.1.19-r11 \
+        readline=7.0.003-r0 \
+    && apk del build-deps \
+    && git clone -b master ${IPMITOOL_REPO}
+
+WORKDIR /tmp/ipmitool
+RUN git checkout ${IPMITOOL_COMMIT} \
+    && ./bootstrap \
+    && ./configure \
         --prefix=/usr/local \
         --enable-ipmievd \
         --enable-ipmishell \
         --enable-intf-lan \
         --enable-intf-lanplus \
         --enable-intf-open \
-        && \
-    make && \
-    make install && \
-    cd $OLDPWD && \
-    rm -rf /tmp/ipmitool && \
-    apk del build-deps
+    && make \
+    && make install
 
-RUN wget -O/tmp/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-		chmod +x /tmp/grpc_health_probe
+WORKDIR /tmp
+RUN rm -rf /tmp/ipmitool \
+    && wget -O/tmp/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 \
+    && chmod +x /tmp/grpc_health_probe
 
 ENV GIN_MODE release 
 USER pbnj

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,6 @@ cover: ## Run unit tests with coverage report
 	go tool cover -func=cover.out
 	rm -rf cover.out
 
-.PHONY: lint
-lint:  ## run linting
-	@echo be sure golangci-lint is installed: https://golangci-lint.run/usage/install/
-	golangci-lint run
-
 .PHONY: buf-lint
 buf-lint:  ## run linting
 	@echo be sure buf is installed: https://buf.build/docs/installation
@@ -107,3 +102,44 @@ ruby-client-demo: image ## run ruby client demo
 .PHONY: evans
 evans: ## run evans grpc client
 	evans --path $$(go env GOMODCACHE) --path . --proto $$(find api/v1 -type f -name '*.proto'| xargs | tr " " ",") repl
+
+# BEGIN: lint-install .
+# http://github.com/tinkerbell/lint-install
+
+GOLINT_VERSION ?= v1.42.0
+HADOLINT_VERSION ?= v2.7.0
+SHELLCHECK_VERSION ?= v0.7.2
+LINT_OS := $(shell uname)
+LINT_ARCH := $(shell uname -m)
+
+# shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
+ifeq ($(LINT_OS),Darwin)
+	ifeq ($(LINT_ARCH),arm64)
+		LINT_ARCH=x86_64
+	endif
+endif
+
+LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
+GOLINT_CONFIG:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/.golangci.yml
+
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
+	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) -t info $(shell find . -name "*Dockerfile")
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
+
+out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
+	mkdir -p out/linters
+	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+
+out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
+	mkdir -p out/linters
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+
+out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+	mkdir -p out/linters
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+
+# END: lint-install .

--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/tinkerbell/pbnj/api/v1"
 )
 
-// MachinePower executes a power action against the server and retrieves status
+// MachinePower executes a power action against the server and retrieves status.
 func MachinePower(ctx context.Context, client v1.MachineClient, taskClient v1.TaskClient, request *v1.PowerRequest) (*v1.StatusResponse, error) {
 	var statusResp *v1.StatusResponse
 	response, err := client.Power(ctx, request)
@@ -25,10 +25,9 @@ func MachinePower(ctx context.Context, client v1.MachineClient, taskClient v1.Ta
 		time.Sleep(1 * time.Second)
 	}
 	return statusResp, nil
-
 }
 
-// MachineBootDev sets the next boot device for a machine
+// MachineBootDev sets the next boot device for a machine.
 func MachineBootDev(ctx context.Context, client v1.MachineClient, taskClient v1.TaskClient, request *v1.DeviceRequest) (*v1.StatusResponse, error) {
 	var statusResp *v1.StatusResponse
 	response, err := client.BootDevice(ctx, request)
@@ -48,7 +47,7 @@ func MachineBootDev(ctx context.Context, client v1.MachineClient, taskClient v1.
 	return statusResp, nil
 }
 
-// BMCCreateUser creates a BMC user
+// BMCCreateUser creates a BMC user.
 func BMCCreateUser(ctx context.Context, client v1.BMCClient, taskClient v1.TaskClient, request *v1.CreateUserRequest) (*v1.StatusResponse, error) {
 	var statusResp *v1.StatusResponse
 	response, err := client.CreateUser(ctx, request)
@@ -68,7 +67,7 @@ func BMCCreateUser(ctx context.Context, client v1.BMCClient, taskClient v1.TaskC
 	return statusResp, nil
 }
 
-// BMCUpdateUser updates a BMC user
+// BMCUpdateUser updates a BMC user.
 func BMCUpdateUser(ctx context.Context, client v1.BMCClient, taskClient v1.TaskClient, request *v1.UpdateUserRequest) (*v1.StatusResponse, error) {
 	var statusResp *v1.StatusResponse
 	response, err := client.UpdateUser(ctx, request)
@@ -88,7 +87,7 @@ func BMCUpdateUser(ctx context.Context, client v1.BMCClient, taskClient v1.TaskC
 	return statusResp, nil
 }
 
-// BMCDeleteUser updates a BMC user
+// BMCDeleteUser updates a BMC user.
 func BMCDeleteUser(ctx context.Context, client v1.BMCClient, taskClient v1.TaskClient, request *v1.DeleteUserRequest) (*v1.StatusResponse, error) {
 	var statusResp *v1.StatusResponse
 	response, err := client.DeleteUser(ctx, request)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// clientCmd represents the server command
+// clientCmd represents the server command.
 var clientCmd = &cobra.Command{
 	Use:   "client",
 	Short: "Run PBnJ client",

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// machineCmd represents the server command
+// machineCmd represents the server command.
 var machineCmd = &cobra.Command{
 	Use:   "machine",
 	Short: "Run PBnJ client machine actions",
@@ -31,7 +31,12 @@ var machineCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
-		defer zlog.Sync() // nolint
+
+		defer func() {
+			if err := zlog.Sync(); err != nil {
+				fmt.Fprintf(os.Stderr, "zlog sync failed: %v", err)
+			}
+		}()
 
 		opts = append(opts, grpc.WithInsecure())
 		conn, err := grpc.Dial("localhost:"+port, opts...)
@@ -66,7 +71,6 @@ var machineCmd = &cobra.Command{
 		}
 
 		logger.V(0).Info("resp", "resp", []interface{}{resp})
-
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ var (
 	prefix   = "pbnj"
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "pbnj",
 	Short: "PBnJ does all your power, boot and jelly goodness for your BMCs",
@@ -27,7 +27,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// NewRootCmd is used for testing to run the server
+// NewRootCmd is used for testing to run the server.
 func NewRootCmd() *cobra.Command {
 	return rootCmd
 }
@@ -65,7 +65,7 @@ func initConfig(cmd *cobra.Command) error {
 	return nil
 }
 
-// Bind each cobra flag to its associated viper configuration (config file and environment variable)
+// Bind each cobra flag to its associated viper configuration (config file and environment variable).
 func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		// Environment variables can't have dashes in them, so bind them to their equivalent

--- a/examples/clients/ruby/demo.sh
+++ b/examples/clients/ruby/demo.sh
@@ -4,8 +4,9 @@
 function setup() {
     gem install grpc grpc-tools > /dev/null 2>&1
     apt update > /dev/null 2>&1; apt -y install jq > /dev/null 2>&1
-    for proto in $(ls ../../../api/v1/*.proto); do
-        grpc_tools_ruby_protoc -I ../../.. --ruby_out=./lib --grpc_out=./lib $proto 
+
+    for proto in ../../../api/v1/*.proto; do
+        grpc_tools_ruby_protoc -I ../../.. --ruby_out=./lib --grpc_out=./lib "${proto}" 
     done
 }
 
@@ -35,4 +36,4 @@ end_progress
 echo -ne "done\n"
 
 echo -e "calling PBnJ endpoint"
-ruby main.rb $1 $2 $3 | jq
+ruby main.rb "$1" "$2" "$3" | jq

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -8,13 +8,13 @@ import (
 
 type HealthChecker struct{}
 
-func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+func (s *HealthChecker) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
 	}, nil
 }
 
-func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+func (s *HealthChecker) Watch(_ *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
 	return server.Send(&grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
 	})

--- a/pkg/http/handlers.go
+++ b/pkg/http/handlers.go
@@ -5,21 +5,21 @@ import (
 	"net/http"
 )
 
-func (h *HTTPServer) runningTasks() int {
+func (h *Server) runningTasks() int {
 	if h.taskRunner == nil {
 		return 0
 	}
 	return h.taskRunner.ActiveWorkers()
 }
 
-func (h *HTTPServer) totalTasks() int {
+func (h *Server) totalTasks() int {
 	if h.taskRunner == nil {
 		return 0
 	}
 	return h.taskRunner.TotalWorkers()
 }
 
-func (h *HTTPServer) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
+func (h *Server) handleHealthcheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write([]byte(fmt.Sprintf(`{"running_tasks": %d, "total_tasks": %d}`, h.runningTasks(), h.totalTasks())))
 	if err != nil {
@@ -27,7 +27,7 @@ func (h *HTTPServer) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *HTTPServer) handleReady(w http.ResponseWriter, r *http.Request) {
+func (h *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write([]byte(`{"ready": true}`))
 	if err != nil {
@@ -35,7 +35,7 @@ func (h *HTTPServer) handleReady(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *HTTPServer) handleLive(w http.ResponseWriter, r *http.Request) {
+func (h *Server) handleLive(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write([]byte(`{"live": true}`))
 	if err != nil {

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -8,24 +8,24 @@ import (
 	"github.com/tinkerbell/pbnj/server/grpcsvr/taskrunner"
 )
 
-type HTTPServer struct {
+type Server struct {
 	address    string
 	logger     logr.Logger
 	mux        *http.ServeMux
 	taskRunner *taskrunner.Runner
 }
 
-func (h *HTTPServer) WithLogger(log logr.Logger) *HTTPServer {
+func (h *Server) WithLogger(log logr.Logger) *Server {
 	h.logger = log
 	return h
 }
 
-func (h *HTTPServer) WithTaskRunner(runner *taskrunner.Runner) *HTTPServer {
+func (h *Server) WithTaskRunner(runner *taskrunner.Runner) *Server {
 	h.taskRunner = runner
 	return h
 }
 
-func (h *HTTPServer) init() {
+func (h *Server) init() {
 	h.mux = http.NewServeMux()
 	h.mux.Handle("/metrics", promhttp.Handler())
 	h.mux.HandleFunc("/healthcheck", h.handleHealthcheck)
@@ -33,12 +33,12 @@ func (h *HTTPServer) init() {
 	h.mux.HandleFunc("/_/live", h.handleLive)
 }
 
-func (h *HTTPServer) Run() error {
+func (h *Server) Run() error {
 	return http.ListenAndServe(h.address, h.mux)
 }
 
-func NewHTTPServer(addr string) *HTTPServer {
-	server := &HTTPServer{
+func NewServer(addr string) *Server {
+	server := &Server{
 		address: addr,
 	}
 	server.init()

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// Logger represent common interface for logging function
+// Logger represent common interface for logging function.
 type Logger interface {
 	logr.Logger
 	GetContextLogger(ctx context.Context) logr.Logger

--- a/pkg/oob/oob.go
+++ b/pkg/oob/oob.go
@@ -7,18 +7,18 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// PowerSetter management methods
+// PowerSetter management methods.
 type PowerSetter interface {
 	// Power get status and sets power states like on/off/etc
 	PowerSet(ctx context.Context, action string) (result string, err error)
 }
 
-// BootDeviceSetter takes care of resetting a BMC
+// BootDeviceSetter takes care of resetting a BMC.
 type BootDeviceSetter interface {
 	BootDeviceSet(ctx context.Context, device string, persistent, efiBoot bool) (result string, err error)
 }
 
-// BMC management methods
+// BMC management methods.
 type BMC interface {
 	// NetworkSource() (result string, err repository.Error)
 	CreateUser(context.Context) error
@@ -26,14 +26,14 @@ type BMC interface {
 	DeleteUser(context.Context) error
 }
 
-// BMCResetter options
+// BMCResetter options.
 type BMCResetter interface {
 	// BMCReset resets the management console without rebooting the BMC (warm) or
 	// Reboots the BMC (cold)
 	BMCReset(ctx context.Context, rType string) error
 }
 
-// SetPower interface function for power actions
+// SetPower interface function for power actions.
 func SetPower(ctx context.Context, action string, m []PowerSetter) (result string, err error) {
 	for _, elem := range m {
 		select {
@@ -55,7 +55,7 @@ func SetPower(ctx context.Context, action string, m []PowerSetter) (result strin
 	return result, multierror.Append(err, errors.New("power state failed"))
 }
 
-// SetBootDevice interface function for setting next boot device
+// SetBootDevice interface function for setting next boot device.
 func SetBootDevice(ctx context.Context, device string, persistent, efiBoot bool, m []BootDeviceSetter) (result string, err error) {
 	for _, elem := range m {
 		select {
@@ -77,7 +77,7 @@ func SetBootDevice(ctx context.Context, device string, persistent, efiBoot bool,
 	return result, multierror.Append(err, errors.New("set boot device failed"))
 }
 
-// CreateUser interface function
+// CreateUser interface function.
 func CreateUser(ctx context.Context, u []BMC) (err error) {
 	for _, elem := range u {
 		select {
@@ -99,7 +99,7 @@ func CreateUser(ctx context.Context, u []BMC) (err error) {
 	return multierror.Append(err, errors.New("create user failed"))
 }
 
-// UpdateUser interface function
+// UpdateUser interface function.
 func UpdateUser(ctx context.Context, u []BMC) (err error) {
 	for _, elem := range u {
 		select {
@@ -121,7 +121,7 @@ func UpdateUser(ctx context.Context, u []BMC) (err error) {
 	return multierror.Append(err, errors.New("update user failed"))
 }
 
-// DeleteUser interface function
+// DeleteUser interface function.
 func DeleteUser(ctx context.Context, u []BMC) (err error) {
 	for _, elem := range u {
 		select {
@@ -143,7 +143,7 @@ func DeleteUser(ctx context.Context, u []BMC) (err error) {
 	return multierror.Append(err, errors.New("delete user failed"))
 }
 
-// ResetBMC interface function
+// ResetBMC interface function.
 func ResetBMC(ctx context.Context, rType string, r []BMCResetter) (err error) {
 	for _, elem := range r {
 		select {

--- a/pkg/oob/oob_test.go
+++ b/pkg/oob/oob_test.go
@@ -14,42 +14,42 @@ type OOBTester struct {
 	MakeFail bool
 }
 
-func (o *OOBTester) PowerSet(ctx context.Context, action string) (result string, err error) {
+func (o *OOBTester) PowerSet(_ context.Context, action string) (result string, err error) {
 	if o.MakeFail {
 		return result, errors.New("power failed")
 	}
 	return "power action complete: " + action, nil
 }
 
-func (o *OOBTester) BootDeviceSet(ctx context.Context, device string, persistent, efiBoot bool) (result string, err error) {
+func (o *OOBTester) BootDeviceSet(_ context.Context, device string, _, _ bool) (result string, err error) {
 	if o.MakeFail {
 		return result, errors.New("boot device failed")
 	}
 	return "boot device set: " + device, nil
 }
 
-func (o *OOBTester) BMCReset(ctx context.Context, rType string) (err error) {
+func (o *OOBTester) BMCReset(_ context.Context, _ string) (err error) {
 	if o.MakeFail {
 		return errors.New("failed: BMC reset")
 	}
 	return nil
 }
 
-func (o *OOBTester) CreateUser(ctx context.Context) (err error) {
+func (o *OOBTester) CreateUser(_ context.Context) (err error) {
 	if o.MakeFail {
 		return errors.New("create user failed")
 	}
 	return nil
 }
 
-func (o *OOBTester) UpdateUser(ctx context.Context) (err error) {
+func (o *OOBTester) UpdateUser(_ context.Context) (err error) {
 	if o.MakeFail {
 		return errors.New("update user failed")
 	}
 	return nil
 }
 
-func (o *OOBTester) DeleteUser(ctx context.Context) (err error) {
+func (o *OOBTester) DeleteUser(_ context.Context) (err error) {
 	if o.MakeFail {
 		return errors.New("delete user failed")
 	}
@@ -85,14 +85,12 @@ func TestMachinePower(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-
 			} else {
 				diff := cmp.Diff(expectedResult, result)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
-
 		})
 	}
 }
@@ -126,14 +124,12 @@ func TestMachineBootDevice(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-
 			} else {
 				diff := cmp.Diff(expectedResult, result)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/repository/repo.go
+++ b/pkg/repository/repo.go
@@ -4,7 +4,7 @@ package repository
 
 import "fmt"
 
-// Actions interface for interacting with the persistence layer
+// Actions interface for interacting with the persistence layer.
 type Actions interface {
 	Create(id string, val Record) error
 	Get(id string) (Record, error)
@@ -12,10 +12,9 @@ type Actions interface {
 	Delete(id string) error
 }
 
-// Record that is stored in the repo
+// Record that is stored in the repo.
 type Record struct {
-	//*v1.StatusResponse
-	Id          string
+	ID          string
 	Description string
 	Error       *Error
 	State       string
@@ -24,7 +23,7 @@ type Record struct {
 	Messages    []string
 }
 
-// Error for all bmc actions
+// Error for all bmc actions.
 type Error struct {
 	Code    int32
 	Message string
@@ -35,7 +34,7 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("code: %v message: %v details: %v", e.Code, e.Message, e.Details)
 }
 
-// StructuredError returns the error struct for convenience
+// StructuredError returns the error struct for convenience.
 func (e *Error) StructuredError() *Error {
 	return &Error{
 		Code:    e.Code,

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -6,7 +6,7 @@ import (
 	"github.com/tinkerbell/pbnj/pkg/repository"
 )
 
-// Task interface for doing BMC actions
+// Task interface for doing BMC actions.
 type Task interface {
 	Execute(ctx context.Context, description, taskID string, action func(chan string) (string, error))
 	Status(ctx context.Context, taskID string) (record repository.Record, err error)

--- a/pkg/zaplog/middleware.go
+++ b/pkg/zaplog/middleware.go
@@ -14,7 +14,7 @@ import (
 )
 
 // UnaryLogRequestID returns a new unary server interceptors that adds zap.Logger with requestID to the context.
-func UnaryLogRequestID(logger *zap.Logger, requestIDKey, requestIDLogKey string) grpc.UnaryServerInterceptor {
+func UnaryLogRequestID(_ *zap.Logger, requestIDKey, requestIDLogKey string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		t := grpc_ctxtags.Extract(ctx)
 

--- a/pkg/zaplog/zap.go
+++ b/pkg/zaplog/zap.go
@@ -9,17 +9,17 @@ import (
 	"github.com/tinkerbell/pbnj/pkg/logging"
 )
 
-// Logger is a wrapper around zap.SugaredLogger
+// Logger is a wrapper around zap.SugaredLogger.
 type Logger struct {
 	logr.Logger
 }
 
-// GetContextLogger get and return a logger from a ctx
+// GetContextLogger get and return a logger from a ctx.
 func (l Logger) GetContextLogger(ctx context.Context) logr.Logger {
 	return zapr.NewLogger(ctxzap.Extract(ctx))
 }
 
-// RegisterLogger returns a logr and a zap logger (needed for use in grpc interceptors)
+// RegisterLogger returns a logr and a zap logger (needed for use in grpc interceptors).
 func RegisterLogger(log logr.Logger) logging.Logger {
 	return Logger{log}
 }

--- a/scripts/http/verify_power_status.sh
+++ b/scripts/http/verify_power_status.sh
@@ -7,16 +7,23 @@ set -euo pipefail
 exec 1>&2
 
 host=${HOST:-http://localhost:9090}
-access_id=$ACCESS_ID
-access_secret=$ACCESS_SECRET
+# shellcheck disable=SC2153 # unset variable comes from environment
+access_id="${ACCESS_ID}"
+# shellcheck disable=SC2153 # unset variable comes from environment
+access_secret="${ACCESS_SECRET}"
+# shellcheck disable=SC2153 # unset variable comes from environment
+user="${DEVICE_USERNAME}"
+# shellcheck disable=SC2153 # unset variable comes from environment
+pass="${DEVICE_PASSWORD}"
+
 content_type=application/json
-uri=/devices/$1/power
-user=$DEVICE_USERNAME
-pass=$DEVICE_PASSWORD
-manufacturer=${DEVICE_MANUFACTURER:-supermicro}
+uri="/devices/$1/power"
+manufacturer="${DEVICE_MANUFACTURER:-supermicro}"
 
 d=$(TZ=GMT date "+%a, %d %b %Y %T %Z")
-sig=$(echo -n "GET,$content_type,,$uri,$d" | openssl dgst -sha1 -binary -hmac $access_secret | base64)
+sig=$(echo -n "GET,$content_type,,$uri,$d" | openssl dgst -sha1 -binary -hmac "${access_secret}" | base64)
+
+# shellcheck disable=SC2015 # if and/else expression is correct
 curl -fs \
 	-H "X-IPMI-Username: $user" \
 	-H "X-IPMI-Password: $pass" \

--- a/scripts/protoc.sh
+++ b/scripts/protoc.sh
@@ -13,12 +13,12 @@ PROTOS_LOC=api/v1
 PROTOC_VERSION=3.13.0
 
 function installDeps {
-    if ! which protoc 2>&1 >/dev/null; then
+    if ! which protoc &>/dev/null; then
         echo 'Installing protoc...' >&2
-        if ! which unzip 2>&1 >/dev/null; then
-            if which apt 2>&1 >/dev/null; then
+        if ! which unzip &>/dev/null; then
+            if which apt &>/dev/null; then
                 apt update; apt install -y zip
-            elif which yum 2>&1 >/dev/null; then
+            elif which yum &>/dev/null; then
                 yum -y install zip
             else
                 echo 'Unknown package manager' >&2
@@ -44,12 +44,12 @@ if [[ "$1" == "deps" ]]; then
     installDeps
     exit 0
 fi
-pbs=$(find ${PROTOS_LOC} -type f -name '*.proto'| xargs | tr " " ",")
+pbs=$(find ${PROTOS_LOC} -type f -name '*.proto' -print0 | xargs -0 | tr " " ",")
 
 echo -n "Generating code from protocol buffers (${pbs})..."
-protoc -I . -I $(go env GOMODCACHE) --go_out=. --go_opt=module=${REPO} ${PROTOS_LOC}/*.proto
-protoc -I . -I $(go env GOMODCACHE) --govalidators_out=. --go-grpc_out=. --go-grpc_opt=module=${REPO} ${PROTOS_LOC}/*.proto
+protoc -I . -I "$(go env GOMODCACHE)" --go_out=. --go_opt=module=${REPO} ${PROTOS_LOC}/*.proto
+protoc -I . -I "$(go env GOMODCACHE)" --govalidators_out=. --go-grpc_out=. --go-grpc_opt=module=${REPO} ${PROTOS_LOC}/*.proto
 mv ${REPO}/${PROTOS_LOC}/*.go ${PROTOS_LOC}/
 rm -rf github.com
-$(go env GOPATH)/bin/goimports -w . || true
+"$(go env GOPATH)/bin/goimports" -w . || true
 echo "done"

--- a/scripts/run-image.sh
+++ b/scripts/run-image.sh
@@ -8,9 +8,9 @@
 trap ctrl_c INT
 
 function ctrl_c() {
-    docker rm -f ${CONTAINER_ID}
+    docker rm -f "${CONTAINER_ID}"
     exit 0
 }
 
 CONTAINER_ID=$(docker run -d -e ACCESS_ID=1234 -e ACCESS_SECRET=1234 -e PNBJ_LOGLEVEL=debug -e PBNJ_ENABLEHTTP=true -p 9090:9090 -p 50051:50051 -p 8080:8080 pbnj:local)
-docker logs -f ${CONTAINER_ID} 2>&1 | jq -R 'fromjson? | select(type == "object")'
+docker logs -f "${CONTAINER_ID}" 2>&1 | jq -R 'fromjson? | select(type == "object")'

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -11,8 +11,8 @@
 trap ctrl_c INT
 
 function ctrl_c() {
-    kill ${RUN_PID}
-    kill $(<pid)
+    kill "${RUN_PID}"
+    kill "$(<pid)"
     rm -rf temp.in pid
     exit 0
 }

--- a/server/grpcsvr/oob/bmc/bmc_test.go
+++ b/server/grpcsvr/oob/bmc/bmc_test.go
@@ -90,7 +90,6 @@ func TestBMCReset(t *testing.T) {
 					}
 				}
 			}
-
 		})
 	}
 }

--- a/server/grpcsvr/oob/bmc/users_bmclib.go
+++ b/server/grpcsvr/oob/bmc/users_bmclib.go
@@ -40,11 +40,11 @@ func (b *bmclibUserManagement) Connect(ctx context.Context) error {
 	return b.conn.CheckCredentials()
 }
 
-func (b *bmclibUserManagement) Close(ctx context.Context) {
+func (b *bmclibUserManagement) Close(_ context.Context) {
 	b.conn.Close()
 }
 
-func (b *bmclibUserManagement) CreateUser(ctx context.Context) error {
+func (b *bmclibUserManagement) CreateUser(_ context.Context) error {
 	users := []*cfgresources.User{
 		{
 			Name:     b.creds.Username,
@@ -53,17 +53,18 @@ func (b *bmclibUserManagement) CreateUser(ctx context.Context) error {
 			Enable:   true,
 		},
 	}
-	err := b.conn.User(users)
-	if err != nil {
+
+	if err := b.conn.User(users); err != nil {
 		return &repository.Error{
 			Code:    v1.Code_value["UNKNOWN"],
 			Message: err.Error(),
 		}
 	}
+
 	return nil
 }
 
-func (b *bmclibUserManagement) UpdateUser(ctx context.Context) error {
+func (b *bmclibUserManagement) UpdateUser(_ context.Context) error {
 	users := []*cfgresources.User{
 		{
 			Name:     b.creds.Username,
@@ -72,17 +73,18 @@ func (b *bmclibUserManagement) UpdateUser(ctx context.Context) error {
 			Enable:   true,
 		},
 	}
-	err := b.conn.User(users)
-	if err != nil {
+
+	if err := b.conn.User(users); err != nil {
 		return &repository.Error{
 			Code:    v1.Code_value["UNKNOWN"],
 			Message: err.Error(),
 		}
 	}
+
 	return nil
 }
 
-func (b *bmclibUserManagement) DeleteUser(ctx context.Context) error {
+func (b *bmclibUserManagement) DeleteUser(_ context.Context) error {
 	users := []*cfgresources.User{
 		{
 			Name:     b.creds.Username,
@@ -91,13 +93,14 @@ func (b *bmclibUserManagement) DeleteUser(ctx context.Context) error {
 			Enable:   false,
 		},
 	}
-	err := b.conn.User(users)
-	if err != nil {
+
+	if err := b.conn.User(users); err != nil {
 		return &repository.Error{
 			Code:    v1.Code_value["UNKNOWN"],
 			Message: err.Error(),
 		}
 	}
+
 	return nil
 }
 

--- a/server/grpcsvr/oob/common.go
+++ b/server/grpcsvr/oob/common.go
@@ -10,24 +10,24 @@ import (
 	"github.com/tinkerbell/pbnj/pkg/repository"
 )
 
-// Connection methods open/close
+// Connection methods open/close.
 type Connection interface {
 	Connect(context.Context) error
 	Close(context.Context)
 }
 
-// Accessory for all BMC actions
+// Accessory for all BMC actions.
 type Accessory struct {
 	Log            logr.Logger
 	StatusMessages chan string
 }
 
-// Connect to a BMC interface function
+// Connect to a BMC interface function.
 func Connect(ctx context.Context, conn Connection) error {
 	return conn.Connect(ctx)
 }
 
-// Close a BMC interface function
+// Close a BMC interface function.
 func Close(ctx context.Context, conn Connection) {
 	conn.Close(ctx)
 }
@@ -71,7 +71,7 @@ func EstablishConnections(ctx context.Context, bmcs map[string]interface{}) (suc
 	return successfulConnections, nil
 }
 
-// ParseAuth will return host, user, passwd from auth struct
+// ParseAuth will return host, user, passwd from auth struct.
 func (a *Accessory) ParseAuth(auth *v1.Authn) (host string, username string, passwd string, err error) {
 	var errMsg repository.Error
 	if auth == nil || auth.Authn == nil || auth.GetDirectAuthn() == nil {
@@ -89,7 +89,7 @@ func (a *Accessory) ParseAuth(auth *v1.Authn) (host string, username string, pas
 	return host, username, passwd, nil
 }
 
-// SendStatusMessage will send a message to a string chan
+// SendStatusMessage will send a message to a string chan.
 func (a *Accessory) SendStatusMessage(msg string) {
 	select {
 	case a.StatusMessages <- msg:

--- a/server/grpcsvr/oob/common_test.go
+++ b/server/grpcsvr/oob/common_test.go
@@ -109,14 +109,14 @@ type testConnect struct {
 	makeFail bool
 }
 
-func (t *testConnect) Connect(ctx context.Context) error {
+func (t *testConnect) Connect(_ context.Context) error {
 	if t.makeFail {
 		return errors.New("failed to connect")
 	}
 	return nil
 }
 
-func (t *testConnect) Close(ctx context.Context) {}
+func (t *testConnect) Close(_ context.Context) {}
 
 func TestEstablishConnections(t *testing.T) {
 	testCases := []struct {
@@ -148,7 +148,6 @@ func TestEstablishConnections(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-
 			} else {
 				diff := cmp.Diff(tc.successfulConnections, result)
 				if diff != "" {
@@ -156,7 +155,6 @@ func TestEstablishConnections(t *testing.T) {
 				}
 				Close(context.Background(), tc.implementation)
 			}
-
 		})
 	}
 }

--- a/server/grpcsvr/oob/machine/machine_power_bmclib.go
+++ b/server/grpcsvr/oob/machine/machine_power_bmclib.go
@@ -38,7 +38,7 @@ func (b *bmclibBMC) Connect(ctx context.Context) error {
 	return b.conn.CheckCredentials()
 }
 
-func (b *bmclibBMC) Close(ctx context.Context) {
+func (b *bmclibBMC) Close(_ context.Context) {
 	b.conn.Close()
 }
 
@@ -74,7 +74,7 @@ func doBmclibAction(ctx context.Context, action string, pwr *bmclibBMC) (result 
 	return result, err
 }
 
-func (b *bmclibBMC) on(ctx context.Context) (result string, err error) {
+func (b *bmclibBMC) on(_ context.Context) (result string, err error) {
 	ok, err := b.conn.PowerOn()
 	if err != nil {
 		return result, &repository.Error{
@@ -88,10 +88,10 @@ func (b *bmclibBMC) on(ctx context.Context) (result string, err error) {
 			Message: "error powering on",
 		}
 	}
-	return "on", nil
+	return On, nil
 }
 
-func (b *bmclibBMC) off(ctx context.Context) (result string, err error) {
+func (b *bmclibBMC) off(_ context.Context) (result string, err error) {
 	ok, err := b.conn.PowerOff()
 	if err != nil {
 		return result, &repository.Error{
@@ -105,10 +105,10 @@ func (b *bmclibBMC) off(ctx context.Context) (result string, err error) {
 			Message: "error powering off",
 		}
 	}
-	return "off", nil
+	return Off, nil
 }
 
-func (b *bmclibBMC) status(ctx context.Context) (result string, err error) {
+func (b *bmclibBMC) status(_ context.Context) (result string, err error) {
 	result, err = b.conn.PowerState()
 	if err != nil {
 		return result, &repository.Error{
@@ -119,7 +119,7 @@ func (b *bmclibBMC) status(ctx context.Context) (result string, err error) {
 	return result, nil
 }
 
-func (b *bmclibBMC) reset(ctx context.Context) (result string, err error) {
+func (b *bmclibBMC) reset(_ context.Context) (result string, err error) {
 	ok, err := b.conn.PowerCycle()
 	if err != nil {
 		return result, &repository.Error{
@@ -133,10 +133,10 @@ func (b *bmclibBMC) reset(ctx context.Context) (result string, err error) {
 			Message: "error with power reset",
 		}
 	}
-	return "reset", nil
+	return Reset, nil
 }
 
-func (b *bmclibBMC) hardoff(ctx context.Context) (result string, err error) {
+func (b *bmclibBMC) hardoff(_ context.Context) (result string, err error) {
 	ok, err := b.conn.PowerOff()
 	if err != nil {
 		return result, &repository.Error{
@@ -153,7 +153,7 @@ func (b *bmclibBMC) hardoff(ctx context.Context) (result string, err error) {
 	return "hardoff", nil
 }
 
-func (b *bmclibBMC) cycle(ctx context.Context) (result string, err error) {
+func (b *bmclibBMC) cycle(_ context.Context) (result string, err error) {
 	ok, err := b.conn.PowerCycle()
 	if err != nil {
 		return result, &repository.Error{

--- a/server/grpcsvr/oob/machine/machine_power_bmclib2.go
+++ b/server/grpcsvr/oob/machine/machine_power_bmclib2.go
@@ -20,7 +20,7 @@ type bmclibClient struct {
 
 func (b *bmclibClient) Connect(ctx context.Context) error {
 	b.conn = bmclib.NewClient(b.host, "623", b.user, b.password, bmclib.WithLogger(b.log))
-	//b.conn.Registry.Drivers = b.conn.Registry.FilterForCompatible(ctx)
+	// b.conn.Registry.Drivers = b.conn.Registry.FilterForCompatible(ctx)
 	return b.conn.Open(ctx)
 }
 

--- a/server/grpcsvr/oob/machine/machine_power_ipmi.go
+++ b/server/grpcsvr/oob/machine/machine_power_ipmi.go
@@ -88,7 +88,7 @@ func (b *ipmiBMC) on(ctx context.Context) (result string, err error) {
 			Message: err.Error(),
 		}
 	}
-	return "on", nil
+	return On, nil
 }
 
 func (b *ipmiBMC) off(ctx context.Context) (result string, err error) {
@@ -99,7 +99,7 @@ func (b *ipmiBMC) off(ctx context.Context) (result string, err error) {
 			Message: err.Error(),
 		}
 	}
-	return "off", nil
+	return Off, nil
 }
 
 func (b *ipmiBMC) status(ctx context.Context) (result string, err error) {
@@ -125,7 +125,7 @@ func (b *ipmiBMC) reset(ctx context.Context) (result string, err error) {
 			Message: err.Error(),
 		}
 	}
-	return "reset", nil
+	return Reset, nil
 }
 
 func (b *ipmiBMC) hardoff(ctx context.Context) (result string, err error) {

--- a/server/grpcsvr/oob/machine/machine_power_redfish.go
+++ b/server/grpcsvr/oob/machine/machine_power_redfish.go
@@ -22,7 +22,7 @@ type redfishBMC struct {
 	host     string
 }
 
-func (r *redfishBMC) Connect(ctx context.Context) error {
+func (r *redfishBMC) Connect(_ context.Context) error {
 	var errMsg repository.Error
 	config := gofish.ClientConfig{
 		Endpoint: "https://" + r.host,
@@ -41,7 +41,7 @@ func (r *redfishBMC) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (r *redfishBMC) Close(ctx context.Context) {
+func (r *redfishBMC) Close(_ context.Context) {
 	r.conn.Logout()
 }
 
@@ -77,7 +77,7 @@ func doRedfishAction(ctx context.Context, action string, pwr *redfishBMC) (resul
 	return result, err
 }
 
-func (r *redfishBMC) on(ctx context.Context) (result string, err error) {
+func (r *redfishBMC) on(_ context.Context) (result string, err error) {
 	var errMsg repository.Error
 	service := r.conn.Service
 	ss, err := service.Systems()
@@ -97,10 +97,10 @@ func (r *redfishBMC) on(ctx context.Context) (result string, err error) {
 			return result, &errMsg
 		}
 	}
-	return "on", nil
+	return On, nil
 }
 
-func (r *redfishBMC) off(ctx context.Context) (result string, err error) {
+func (r *redfishBMC) off(_ context.Context) (result string, err error) {
 	var errMsg repository.Error
 	service := r.conn.Service
 	ss, err := service.Systems()
@@ -120,10 +120,10 @@ func (r *redfishBMC) off(ctx context.Context) (result string, err error) {
 			return result, &errMsg
 		}
 	}
-	return "off", nil
+	return Off, nil
 }
 
-func (r *redfishBMC) status(ctx context.Context) (result string, err error) {
+func (r *redfishBMC) status(_ context.Context) (result string, err error) {
 	var errMsg repository.Error
 	service := r.conn.Service
 	ss, err := service.Systems()
@@ -160,13 +160,13 @@ func (r *redfishBMC) reset(ctx context.Context) (result string, err error) {
 				time.Sleep(1 * time.Second)
 			}
 			_, errMsg := r.on(ctx)
-			return "reset", errMsg
+			return Reset, errMsg
 		}
 	}
-	return "reset", nil
+	return Reset, nil
 }
 
-func (r *redfishBMC) hardoff(ctx context.Context) (result string, err error) {
+func (r *redfishBMC) hardoff(_ context.Context) (result string, err error) {
 	var errMsg repository.Error
 	service := r.conn.Service
 	ss, err := service.Systems()

--- a/server/grpcsvr/oob/machine/machine_test.go
+++ b/server/grpcsvr/oob/machine/machine_test.go
@@ -99,7 +99,6 @@ func TestBootDevice(t *testing.T) {
 					t.Fatal(diff)
 				}
 			}
-
 		})
 	}
 }

--- a/server/grpcsvr/persistence/repo.go
+++ b/server/grpcsvr/persistence/repo.go
@@ -4,24 +4,22 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/philippgille/gokv"
 	"github.com/tinkerbell/pbnj/pkg/repository"
 )
 
-// GoKV store, methods implement repository.Actions interface
+// GoKV store, methods implement repository.Actions interface.
 type GoKV struct {
 	Ctx   context.Context
 	Store gokv.Store
 }
 
-// Create a record
+// Create a record.
 func (g *GoKV) Create(id string, val repository.Record) error {
 	return g.Store.Set(id, val)
 }
 
-// Get a record
+// Get a record.
 func (g *GoKV) Get(id string) (repository.Record, error) {
 	rec := new(repository.Record)
 	found, err := g.Store.Get(id, rec)
@@ -29,12 +27,12 @@ func (g *GoKV) Get(id string) (repository.Record, error) {
 		return *rec, err
 	}
 	if !found {
-		err = errors.New(fmt.Sprintf("record id not found: %v", id))
+		err = fmt.Errorf("record id not found: %v", id)
 	}
 	return *rec, err
 }
 
-// Update a record
+// Update a record.
 func (g *GoKV) Update(id string, val repository.Record) error {
 	rec := new(repository.Record)
 	found, err := g.Store.Get(id, rec)
@@ -42,12 +40,12 @@ func (g *GoKV) Update(id string, val repository.Record) error {
 		return err
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("record id not found: %v", id))
+		return fmt.Errorf("record id not found: %v", id)
 	}
 	return g.Store.Set(id, val)
 }
 
-// Delete a record
+// Delete a record.
 func (g *GoKV) Delete(id string) error {
 	return g.Store.Delete(id)
 }

--- a/server/grpcsvr/persistence/repo_test.go
+++ b/server/grpcsvr/persistence/repo_test.go
@@ -20,7 +20,7 @@ func TestAllMethods(t *testing.T) {
 	defer s.Close()
 	repo := &GoKV{Store: s, Ctx: ctx}
 	record := repository.Record{
-		Id:          id,
+		ID:          id,
 		Description: "test record",
 		Error:       nil,
 		State:       "running",
@@ -28,7 +28,7 @@ func TestAllMethods(t *testing.T) {
 		Complete:    false,
 	}
 	expected := repository.Record{
-		Id:          id,
+		ID:          id,
 		Description: "test record",
 		Error:       nil,
 		State:       "running",
@@ -36,7 +36,7 @@ func TestAllMethods(t *testing.T) {
 		Complete:    false,
 	}
 	expectedUpdated := repository.Record{
-		Id:          id,
+		ID:          id,
 		Description: "test record",
 		Error:       nil,
 		State:       "complete",
@@ -78,7 +78,6 @@ func TestAllMethods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestGetRecordNotFound(t *testing.T) {

--- a/server/grpcsvr/rpc/bmc.go
+++ b/server/grpcsvr/rpc/bmc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tinkerbell/pbnj/server/grpcsvr/oob/bmc"
 )
 
-// BmcService for doing BMC actions
+// BmcService for doing BMC actions.
 type BmcService struct {
 	Log logging.Logger
 	// Timeout is how long a task should be run
@@ -24,12 +24,12 @@ type BmcService struct {
 	v1.UnimplementedBMCServer
 }
 
-// NetworkSource sets the BMC network source
-func (b *BmcService) NetworkSource(ctx context.Context, in *v1.NetworkSourceRequest) (*v1.NetworkSourceResponse, error) {
+// NetworkSource sets the BMC network source.
+func (b *BmcService) NetworkSource(_ context.Context, _ *v1.NetworkSourceRequest) (*v1.NetworkSourceResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
-// Reset calls a reset on a BMC
+// Reset calls a reset on a BMC.
 func (b *BmcService) Reset(ctx context.Context, in *v1.ResetRequest) (*v1.ResetResponse, error) {
 	l := b.Log.GetContextLogger(ctx)
 	taskID := xid.New().String()
@@ -42,8 +42,8 @@ func (b *BmcService) Reset(ctx context.Context, in *v1.ResetRequest) (*v1.ResetR
 		"resetKind", in.GetResetKind().String(),
 	)
 
-	var execFunc = func(s chan string) (string, error) {
-		task, err := bmc.NewBMCResetter(
+	execFunc := func(s chan string) (string, error) {
+		t, err := bmc.NewBMCResetter(
 			bmc.WithLogger(l),
 			bmc.WithStatusMessage(s),
 			bmc.WithResetRequest(in),
@@ -56,14 +56,14 @@ func (b *BmcService) Reset(ctx context.Context, in *v1.ResetRequest) (*v1.ResetR
 		// cant have cancel be _ because go vet complains.
 		// TODO(jacobweinstock): maybe move this context withTimeout into the TaskRunner.Execute function
 		_ = cancel
-		return "", task.BMCReset(taskCtx, in.ResetKind.String())
+		return "", t.BMCReset(taskCtx, in.ResetKind.String())
 	}
 	b.TaskRunner.Execute(ctx, "bmc reset", taskID, execFunc)
 
 	return &v1.ResetResponse{TaskId: taskID}, nil
 }
 
-// CreateUser sets the next boot device of a machine
+// CreateUser sets the next boot device of a machine.
 func (b *BmcService) CreateUser(ctx context.Context, in *v1.CreateUserRequest) (*v1.CreateUserResponse, error) {
 	// TODO figure out how not to have to do this, but still keep the logging abstraction clean?
 	l := b.Log.GetContextLogger(ctx)
@@ -78,8 +78,8 @@ func (b *BmcService) CreateUser(ctx context.Context, in *v1.CreateUserRequest) (
 		"userCreds.UserRole", in.UserCreds.UserRole,
 	)
 
-	var execFunc = func(s chan string) (string, error) {
-		task, err := bmc.NewBMC(
+	execFunc := func(s chan string) (string, error) {
+		t, err := bmc.NewBMC(
 			bmc.WithCreateUserRequest(in),
 			bmc.WithLogger(l),
 			bmc.WithStatusMessage(s),
@@ -89,14 +89,14 @@ func (b *BmcService) CreateUser(ctx context.Context, in *v1.CreateUserRequest) (
 		}
 		taskCtx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		_ = cancel
-		return "", task.CreateUser(taskCtx)
+		return "", t.CreateUser(taskCtx)
 	}
 	b.TaskRunner.Execute(ctx, "creating user", taskID, execFunc)
 
 	return &v1.CreateUserResponse{TaskId: taskID}, nil
 }
 
-// UpdateUser updates a users credentials on a BMC
+// UpdateUser updates a users credentials on a BMC.
 func (b *BmcService) UpdateUser(ctx context.Context, in *v1.UpdateUserRequest) (*v1.UpdateUserResponse, error) {
 	// TODO figure out how not to have to do this, but still keep the logging abstraction clean?
 	l := b.Log.GetContextLogger(ctx)
@@ -111,8 +111,8 @@ func (b *BmcService) UpdateUser(ctx context.Context, in *v1.UpdateUserRequest) (
 		"userCreds.UserRole", in.UserCreds.UserRole,
 	)
 
-	var execFunc = func(s chan string) (string, error) {
-		task, err := bmc.NewBMC(
+	execFunc := func(s chan string) (string, error) {
+		t, err := bmc.NewBMC(
 			bmc.WithUpdateUserRequest(in),
 			bmc.WithLogger(l),
 			bmc.WithStatusMessage(s),
@@ -122,14 +122,14 @@ func (b *BmcService) UpdateUser(ctx context.Context, in *v1.UpdateUserRequest) (
 		}
 		taskCtx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		_ = cancel
-		return "", task.UpdateUser(taskCtx)
+		return "", t.UpdateUser(taskCtx)
 	}
 	b.TaskRunner.Execute(ctx, "updating user", taskID, execFunc)
 
 	return &v1.UpdateUserResponse{TaskId: taskID}, nil
 }
 
-// DeleteUser deletes a user on a BMC
+// DeleteUser deletes a user on a BMC.
 func (b *BmcService) DeleteUser(ctx context.Context, in *v1.DeleteUserRequest) (*v1.DeleteUserResponse, error) {
 	// TODO figure out how not to have to do this, but still keep the logging abstraction clean?
 	l := b.Log.GetContextLogger(ctx)
@@ -142,8 +142,8 @@ func (b *BmcService) DeleteUser(ctx context.Context, in *v1.DeleteUserRequest) (
 		"userCreds.Username", in.Username,
 	)
 
-	var execFunc = func(s chan string) (string, error) {
-		task, err := bmc.NewBMC(
+	execFunc := func(s chan string) (string, error) {
+		t, err := bmc.NewBMC(
 			bmc.WithDeleteUserRequest(in),
 			bmc.WithLogger(l),
 			bmc.WithStatusMessage(s),
@@ -153,7 +153,7 @@ func (b *BmcService) DeleteUser(ctx context.Context, in *v1.DeleteUserRequest) (
 		}
 		taskCtx, cancel := context.WithTimeout(context.Background(), b.Timeout)
 		_ = cancel
-		return "", task.DeleteUser(taskCtx)
+		return "", t.DeleteUser(taskCtx)
 	}
 	b.TaskRunner.Execute(ctx, "deleting user", taskID, execFunc)
 

--- a/server/grpcsvr/rpc/bmc_test.go
+++ b/server/grpcsvr/rpc/bmc_test.go
@@ -61,15 +61,14 @@ func setup() {
 	}
 	_, err := exec.LookPath("ipmitool")
 	if err != nil {
-		err := ioutil.WriteFile(tempIPMITool, []byte{}, 0777)
+		err := ioutil.WriteFile(tempIPMITool, []byte{}, 0o777)
 		if err != nil {
 			fmt.Println("didnt find ipmitool in PATH and couldnt create one in /tmp")
-			os.Exit(3)
+			os.Exit(3) //nolint:revive // deep-exit here is OK
 		}
 		path := os.Getenv("PATH")
 		os.Setenv("PATH", fmt.Sprintf("%v:/tmp", path))
 	}
-
 }
 
 func teardown() {
@@ -112,7 +111,7 @@ func TestConfigNetworkSource(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			response, err := bmcService.NetworkSource(ctx, testCase.req)
 			if response != nil {
-				t.Fatalf("reponse should be nil, got: %v", response)
+				t.Fatalf("response should be nil, got: %v", response)
 			}
 			if diff := cmp.Diff(tc.expectedErr.Error(), err.Error()); diff != "" {
 				t.Fatal(diff)
@@ -152,6 +151,7 @@ func newResetRequest(authErr bool) *v1.ResetRequest {
 		ResetKind: 0,
 	}
 }
+
 func TestReset(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -172,10 +172,8 @@ func TestReset(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-			} else {
-				if response.TaskId == "" {
-					t.Fatal("expected taskId, got:", response.TaskId)
-				}
+			} else if response.TaskId == "" {
+				t.Fatal("expected taskId, got:", response.TaskId)
 			}
 		})
 	}
@@ -216,6 +214,7 @@ func newCreateUserRequest(authErr bool) *v1.CreateUserRequest {
 		},
 	}
 }
+
 func TestCreateUser(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -236,10 +235,8 @@ func TestCreateUser(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-			} else {
-				if response.TaskId == "" {
-					t.Fatal("expected taskId, got:", response.TaskId)
-				}
+			} else if response.TaskId == "" {
+				t.Fatal("expected taskId, got:", response.TaskId)
 			}
 		})
 	}
@@ -280,6 +277,7 @@ func newUpdateUserRequest(authErr bool) *v1.UpdateUserRequest {
 		},
 	}
 }
+
 func TestUpdateUser(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -300,10 +298,8 @@ func TestUpdateUser(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-			} else {
-				if response.TaskId == "" {
-					t.Fatal("expected taskId, got:", response.TaskId)
-				}
+			} else if response.TaskId == "" {
+				t.Fatal("expected taskId, got:", response.TaskId)
 			}
 		})
 	}
@@ -340,6 +336,7 @@ func newDeleteUserRequest(authErr bool) *v1.DeleteUserRequest {
 		Username: "blah",
 	}
 }
+
 func TestDeleteUser(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -360,10 +357,8 @@ func TestDeleteUser(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-			} else {
-				if response.TaskId == "" {
-					t.Fatal("expected taskId, got:", response.TaskId)
-				}
+			} else if response.TaskId == "" {
+				t.Fatal("expected taskId, got:", response.TaskId)
 			}
 		})
 	}

--- a/server/grpcsvr/rpc/machine.go
+++ b/server/grpcsvr/rpc/machine.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tinkerbell/pbnj/server/grpcsvr/oob/machine"
 )
 
-// MachineService for doing power and device actions
+// MachineService for doing power and device actions.
 type MachineService struct {
 	Log logging.Logger
 	// Timeout is how long a task should be run
@@ -23,7 +23,7 @@ type MachineService struct {
 	v1.UnimplementedMachineServer
 }
 
-// BootDevice sets the next boot device of a machine
+// BootDevice sets the next boot device of a machine.
 func (m *MachineService) BootDevice(ctx context.Context, in *v1.DeviceRequest) (*v1.DeviceResponse, error) {
 	// TODO figure out how not to have to do this, but still keep the logging abstraction clean?
 	l := m.Log.GetContextLogger(ctx)
@@ -39,7 +39,7 @@ func (m *MachineService) BootDevice(ctx context.Context, in *v1.DeviceRequest) (
 		"efiBoot", in.EfiBoot,
 	)
 
-	var execFunc = func(s chan string) (string, error) {
+	execFunc := func(s chan string) (string, error) {
 		mbd, err := machine.NewBootDeviceSetter(
 			machine.WithDeviceRequest(in),
 			machine.WithLogger(l),
@@ -57,7 +57,7 @@ func (m *MachineService) BootDevice(ctx context.Context, in *v1.DeviceRequest) (
 	return &v1.DeviceResponse{TaskId: taskID}, nil
 }
 
-// Power does a power action against a BMC
+// Power does a power action against a BMC.
 func (m *MachineService) Power(ctx context.Context, in *v1.PowerRequest) (*v1.PowerResponse, error) {
 	l := m.Log.GetContextLogger(ctx)
 	taskID := xid.New().String()
@@ -71,7 +71,7 @@ func (m *MachineService) Power(ctx context.Context, in *v1.PowerRequest) (*v1.Po
 		"OffDuration", in.OffDuration,
 	)
 
-	var execFunc = func(s chan string) (string, error) {
+	execFunc := func(s chan string) (string, error) {
 		mp, err := machine.NewPowerSetter(
 			machine.WithPowerRequest(in),
 			machine.WithLogger(l),

--- a/server/grpcsvr/rpc/machine_test.go
+++ b/server/grpcsvr/rpc/machine_test.go
@@ -89,7 +89,6 @@ func TestDevice(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-
 			} else {
 				g.Expect(response.TaskId).Should(gomega.HaveLen(20))
 			}
@@ -195,11 +194,9 @@ func TestPower(t *testing.T) {
 				if diff != "" {
 					t.Fatal(diff)
 				}
-
 			} else {
 				g.Expect(response.TaskId).Should(gomega.HaveLen(20))
 			}
-
 		})
 	}
 }

--- a/server/grpcsvr/rpc/task.go
+++ b/server/grpcsvr/rpc/task.go
@@ -10,14 +10,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// TaskService for retrieving task details
+// TaskService for retrieving task details.
 type TaskService struct {
 	Log        logging.Logger
 	TaskRunner task.Task
 	v1.UnimplementedTaskServer
 }
 
-// Status returns a task record
+// Status returns a task record.
 func (t *TaskService) Status(ctx context.Context, in *v1.StatusRequest) (*v1.StatusResponse, error) {
 	l := t.Log.GetContextLogger(ctx)
 	l.V(0).Info("start Status request", "taskID", in.TaskId)
@@ -36,7 +36,7 @@ func (t *TaskService) Status(ctx context.Context, in *v1.StatusRequest) (*v1.Sta
 	}
 
 	return &v1.StatusResponse{
-		Id:          record.Id,
+		Id:          record.ID,
 		Description: record.Description,
 		Error:       errMsg,
 		State:       record.State,

--- a/server/grpcsvr/rpc/task_test.go
+++ b/server/grpcsvr/rpc/task_test.go
@@ -40,7 +40,7 @@ func TestTaskFound(t *testing.T) {
 	}
 	taskID := xid.New().String()
 	taskRunner.Execute(ctx, "test", taskID, func(s chan string) (string, error) {
-		return "doing cool stuff", defaultError // nolint
+		return "doing cool stuff", defaultError
 	})
 
 	taskReq := &v1.StatusRequest{TaskId: taskID}
@@ -58,7 +58,6 @@ func TestTaskFound(t *testing.T) {
 	if taskResp.Id != taskID {
 		t.Fatalf("got: %+v", taskResp)
 	}
-
 }
 
 func TestRecordNotFound(t *testing.T) {

--- a/server/grpcsvr/server.go
+++ b/server/grpcsvr/server.go
@@ -22,27 +22,27 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// Server options
+// Server options.
 type Server struct {
 	repository.Actions
 	bmcTimeout time.Duration
 }
 
-// ServerOption for setting optional values
+// ServerOption for setting optional values.
 type ServerOption func(*Server)
 
-// WithPersistence sets the log level
+// WithPersistence sets the log level.
 func WithPersistence(repo repository.Actions) ServerOption {
 	return func(args *Server) { args.Actions = repo }
 }
 
-// WithBmcTimeout sets the timeout for BMC calls
+// WithBmcTimeout sets the timeout for BMC calls.
 func WithBmcTimeout(t time.Duration) ServerOption {
 	return func(args *Server) { args.bmcTimeout = t }
 }
 
-// RunServer registers all services and runs the server
-func RunServer(ctx context.Context, log logging.Logger, grpcServer *grpc.Server, port string, httpServer *http.HTTPServer, opts ...ServerOption) error {
+// RunServer registers all services and runs the server.
+func RunServer(ctx context.Context, log logging.Logger, grpcServer *grpc.Server, port string, httpServer *http.Server, opts ...ServerOption) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -105,7 +105,7 @@ func RunServer(ctx context.Context, log logging.Logger, grpcServer *grpc.Server,
 		err := httpServer.Run()
 		if err != nil {
 			log.V(0).Error(err, "failed to serve http")
-			os.Exit(1)
+			os.Exit(1) //nolint:revive // removing deep-exit requires a significant refactor
 		}
 	}()
 

--- a/server/grpcsvr/server_test.go
+++ b/server/grpcsvr/server_test.go
@@ -42,7 +42,7 @@ func TestRunServer(t *testing.T) {
 	repo := &persistence.GoKV{Store: s, Ctx: ctx}
 
 	grpcServer := grpc.NewServer()
-	httpServer := http.NewHTTPServer(fmt.Sprintf(":%d", port+1))
+	httpServer := http.NewServer(fmt.Sprintf(":%d", port+1))
 	httpServer.WithLogger(l)
 
 	g := new(errgroup.Group)
@@ -73,7 +73,7 @@ func TestRunServerSignals(t *testing.T) {
 	max := 40045
 	port := rand.Intn(max-min+1) + min
 	grpcServer := grpc.NewServer()
-	httpServer := http.NewHTTPServer(fmt.Sprintf(":%d", port+1))
+	httpServer := http.NewServer(fmt.Sprintf(":%d", port+1))
 	httpServer.WithLogger(l)
 
 	g := new(errgroup.Group)
@@ -113,12 +113,11 @@ func TestRunServerPortInUse(t *testing.T) {
 	}
 
 	grpcServer := grpc.NewServer()
-	httpServer := http.NewHTTPServer(fmt.Sprintf(":%d", port+1))
+	httpServer := http.NewServer(fmt.Sprintf(":%d", port+1))
 	httpServer.WithLogger(l)
 
 	err = RunServer(ctx, log, grpcServer, strconv.Itoa(port), httpServer)
 	if err.Error() != "listen tcp :40039: bind: address already in use" {
 		t.Fatal(err)
 	}
-
 }

--- a/server/grpcsvr/taskrunner/taskrunner_test.go
+++ b/server/grpcsvr/taskrunner/taskrunner_test.go
@@ -51,7 +51,8 @@ func TestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.Complete {
+
+	if !record.Complete {
 		t.Fatalf("expected task to be complete, got: %+v", record)
 	}
 }

--- a/server/grpcsvr/taskrunner/taskrunner_test.go
+++ b/server/grpcsvr/taskrunner/taskrunner_test.go
@@ -38,7 +38,7 @@ func TestRoundTrip(t *testing.T) {
 
 	taskID := xid.New().String()
 	runner.Execute(ctx, description, taskID, func(s chan string) (string, error) {
-		return "didnt do anything", defaultError //nolint
+		return "didnt do anything", defaultError
 	})
 
 	if len(taskID) != 20 {
@@ -51,7 +51,7 @@ func TestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.Complete != true {
+	if record.Complete {
 		t.Fatalf("expected task to be complete, got: %+v", record)
 	}
 }

--- a/server/httpsvr/api/api.go
+++ b/server/httpsvr/api/api.go
@@ -37,7 +37,7 @@ func SetupLogging(l log.Logger) {
 	elog = evlog.New(logger)
 }
 
-// Serve serves http api
+// Serve serves http api.
 func Serve(addr, rev string) error {
 	gitRev = rev
 	r := gin.New()
@@ -99,12 +99,13 @@ func logging(c *gin.Context) {
 	var fields []interface{}
 	tx := elog.TxFromContext(c)
 
-	log := true
+	logThis := true
 	path := c.Request.RequestURI
 	if strings.HasPrefix(path, "/_packet") || path == "/metrics" {
-		log = false
+		logThis = false
 	}
-	if log {
+
+	if logThis {
 		start := time.Now()
 		method := c.Request.Method
 		client := c.ClientIP()
@@ -145,7 +146,7 @@ func recovery(c *gin.Context) {
 		err = errors.WithMessage(err, "panic recovered")
 
 		tx.Panic("request_panic", "error", err)
-		internalServerError(c)
+		internalServerError(c, err)
 	}()
 	c.Next()
 }

--- a/server/httpsvr/api/auth.go
+++ b/server/httpsvr/api/auth.go
@@ -17,9 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	maxRequestAge = 15 * time.Minute
-)
+var maxRequestAge = 15 * time.Minute
 
 func authorize(c *gin.Context) {
 	authHeader := c.Request.Header.Get("Authorization")

--- a/server/httpsvr/api/bmc.go
+++ b/server/httpsvr/api/bmc.go
@@ -26,8 +26,7 @@ func bmcAction(c *gin.Context) {
 	defer func() { _ = driver.Close() }()
 
 	if err := driver.BMC(req.Action); err != nil {
-		c.Error(err) // nolint
-		internalServerError(c)
+		internalServerError(c, err)
 		return
 	}
 	c.Writer.WriteHeader(http.StatusNoContent)

--- a/server/httpsvr/api/boot.go
+++ b/server/httpsvr/api/boot.go
@@ -24,8 +24,7 @@ func updateBootOptions(c *gin.Context) {
 	defer func() { _ = driver.Close() }()
 
 	if err := driver.SetBootOptions(opts); err != nil {
-		c.Error(err) // nolint
-		c.AbortWithStatus(http.StatusInternalServerError)
+		internalServerError(c, err)
 		return
 	}
 

--- a/server/httpsvr/api/errors.go
+++ b/server/httpsvr/api/errors.go
@@ -12,17 +12,17 @@ import (
 )
 
 var (
-	// ErrBadAccessID indicate an invalid access id
+	// ErrBadAccessID indicate an invalid access id.
 	ErrBadAccessID = errors.New("invalid access id")
-	// ErrBadAuthorization indicates an invalid authorization header
+	// ErrBadAuthorization indicates an invalid authorization header.
 	ErrBadAuthorization = errors.New("invalid authorization header")
-	// ErrBadDate indicates an invalid date header
+	// ErrBadDate indicates an invalid date header.
 	ErrBadDate = errors.New("invalid date header")
-	// ErrBadSignature indicates an invalid request signature
+	// ErrBadSignature indicates an invalid request signature.
 	ErrBadSignature = errors.New("invalid request signature")
-	// ErrNotSigned indicates an unsigned request
+	// ErrNotSigned indicates an unsigned request.
 	ErrNotSigned = errors.New("request not signed")
-	// ErrTooOld indicates an expired signature
+	// ErrTooOld indicates an expired signature.
 	ErrTooOld = errors.New("request too old")
 )
 
@@ -53,10 +53,8 @@ func badRequest(c *gin.Context, errs ...error) {
 	c.AbortWithStatus(http.StatusBadRequest)
 }
 
-func internalServerError(c *gin.Context, errs ...error) {
-	for _, err := range errs {
-		_ = c.Error(err)
-	}
+func internalServerError(c *gin.Context, err error) {
+	_ = c.Error(err)
 	c.AbortWithStatus(http.StatusInternalServerError)
 }
 

--- a/server/httpsvr/api/lan.go
+++ b/server/httpsvr/api/lan.go
@@ -26,8 +26,7 @@ func updateLANConfig(c *gin.Context) {
 	defer func() { _ = driver.Close() }()
 
 	if err := driver.SetIPSource(req.IPSource); err != nil {
-		c.Error(err) // nolint
-		internalServerError(c)
+		internalServerError(c, err)
 		return
 	}
 

--- a/server/httpsvr/api/power.go
+++ b/server/httpsvr/api/power.go
@@ -75,13 +75,13 @@ func powerStatus(c *gin.Context) {
 	}
 	defer func() { _ = driver.Close() }()
 
-	if status, err := driver.PowerStatus(); err != nil {
-		c.Error(err) // nolint
-		internalServerError(c)
+	status, err := driver.PowerStatus()
+	if err != nil {
+		internalServerError(c, err)
 		return
-	} else {
-		renderPowerStatus(c, status)
 	}
+
+	renderPowerStatus(c, status)
 }
 
 func renderTaskStarted(c *gin.Context, t *power.Task) {

--- a/server/httpsvr/api/redfish/proxy.go
+++ b/server/httpsvr/api/redfish/proxy.go
@@ -6,6 +6,7 @@ package redfish
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 
@@ -24,7 +25,10 @@ var (
 )
 
 func director(req *http.Request) {
-	ctx := req.Context().Value(redfishCTX).(*gin.Context)
+	ctx, ok := req.Context().Value(redfishCTX).(*gin.Context)
+	if !ok {
+		panic(fmt.Errorf("type assertion failed: %v", redfishCTX))
+	}
 
 	req.URL.Scheme = "https"
 	if req.Header.Get("X-REDFISH-SCHEME") == "http" {
@@ -42,7 +46,7 @@ func director(req *http.Request) {
 }
 
 // redfishProxy is a handler for the ANY /redfish/* endpoint
-// Proxies /device/{ip}/redfish/{path} to {ip}/redfish/{path}
+// Proxies /device/{ip}/redfish/{path} to {ip}/redfish/{path}.
 func Proxy(c *gin.Context) {
 	proxy := proxyTLS
 	if c.Request.Header.Get("X-REDFISH-TLS-VERIFY") == "false" {

--- a/server/httpsvr/drivers/ipmitool/bmc.go
+++ b/server/httpsvr/drivers/ipmitool/bmc.go
@@ -27,7 +27,7 @@ var bmcActions = map[bmc.Action]string{
 	bmc.WarmReset: "reset warm",
 }
 
-// BMC runs actions on the BMC
+// BMC runs actions on the BMC.
 func (s *Shell) BMC(action bmc.Action) error {
 	arg, ok := bmcActions[action]
 	if !ok {

--- a/server/httpsvr/drivers/ipmitool/boot.go
+++ b/server/httpsvr/drivers/ipmitool/boot.go
@@ -30,7 +30,7 @@ var devices = map[boot.Device]string{
 	boot.ForceBIOS:     "bios",
 }
 
-// SetBootOptions sets boot options
+// SetBootOptions sets boot options.
 func (s *Shell) SetBootOptions(opts boot.Options) error {
 	device, ok := devices[opts.Device]
 	if !ok {

--- a/server/httpsvr/drivers/ipmitool/errors.go
+++ b/server/httpsvr/drivers/ipmitool/errors.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	// ErrConnect mimics the ipmitool response when a connection can not be established
+	// ErrConnect mimics the ipmitool response when a connection can not be established.
 	ErrConnect = defineError("Unable to establish IPMI v2 / RMCP+ session")
-	// ErrStatus mimics the ipmitool response when it is unable to get chasis power status
+	// ErrStatus mimics the ipmitool response when it is unable to get chasis power status.
 	ErrStatus = defineError("Unable to get Chassis Power Status")
-	// ErrChannelCipherSuites mimics the ipmitool response when it there is a cypher suites mismatch
+	// ErrChannelCipherSuites mimics the ipmitool response when it there is a cypher suites mismatch.
 	ErrChannelCipherSuites = defineError("Unable to Get Channel Cipher Suites")
 )
 

--- a/server/httpsvr/drivers/ipmitool/lan.go
+++ b/server/httpsvr/drivers/ipmitool/lan.go
@@ -14,7 +14,7 @@ var lanIPSources = map[bmc.IPSource]string{
 	bmc.StaticIP:   "static",
 }
 
-// SetIPSource sets ip configuration method
+// SetIPSource sets ip configuration method.
 func (s *Shell) SetIPSource(source bmc.IPSource) error {
 	arg, ok := lanIPSources[source]
 	if !ok {

--- a/server/httpsvr/drivers/ipmitool/logging.go
+++ b/server/httpsvr/drivers/ipmitool/logging.go
@@ -4,6 +4,6 @@
 package ipmitool
 
 const (
-	// VerboseDebug enables verbose/debug logging
+	// VerboseDebug enables verbose/debug logging.
 	VerboseDebug = false
 )

--- a/server/httpsvr/drivers/ipmitool/options.go
+++ b/server/httpsvr/drivers/ipmitool/options.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 )
 
-var DEFAULT_CIPHER = os.Getenv("IPMITOOL_DEFAULT_CIPHER")
+var cipherFromEnv = os.Getenv("IPMITOOL_DEFAULT_CIPHER")
 
-// ExecutablePath path to ipmitool
+// ExecutablePath path to ipmitool.
 const ExecutablePath = "ipmitool"
 
-// Options are the options ipmitool accepts
+// Options are the options ipmitool accepts.
 type Options struct {
 	Address  string
 	Username string
@@ -26,7 +26,7 @@ type Options struct {
 	RetransSecs   int
 }
 
-// NewOptions returns an Options struct with the values provided set
+// NewOptions returns an Options struct with the values provided set.
 func NewOptions(addr, user, pass string, cipher int) Options {
 	return Options{
 		Address:       addr,
@@ -60,8 +60,8 @@ func (o *Options) buildCommand(subcommand ...string) *exec.Cmd {
 
 	if o.Cipher > -1 {
 		args = append(args, "-C", strconv.Itoa(o.Cipher))
-	} else if DEFAULT_CIPHER != "" {
-		args = append(args, "-C", DEFAULT_CIPHER)
+	} else if cipherFromEnv != "" {
+		args = append(args, "-C", cipherFromEnv)
 	}
 
 	if o.Attempts > 0 {

--- a/server/httpsvr/drivers/ipmitool/power.go
+++ b/server/httpsvr/drivers/ipmitool/power.go
@@ -29,7 +29,7 @@ var powerActions = map[power.Action]string{
 	power.Reset:    "reset",
 }
 
-// Power sets the power state
+// Power sets the power state.
 func (s *Shell) Power(action power.Action) error {
 	arg, ok := powerActions[action]
 	if !ok {
@@ -43,7 +43,7 @@ func (s *Shell) Power(action power.Action) error {
 	return s.Run("power " + arg)
 }
 
-// PowerStatus returns the power state
+// PowerStatus returns the power state.
 func (s *Shell) PowerStatus() (power.Status, error) {
 	err := s.Run("power status")
 	return s.LastStatus(), errors.WithMessage(err, "error retrieving ipmi power status")

--- a/server/httpsvr/drivers/ipmitool/shell.go
+++ b/server/httpsvr/drivers/ipmitool/shell.go
@@ -23,7 +23,7 @@ var (
 	prompt   = `ipmitool> `
 )
 
-// Shell represents an open remote shell
+// Shell represents an open remote shell.
 type Shell struct {
 	Address string
 	tx      *evlog.Tx
@@ -49,18 +49,21 @@ func (s *Shell) debugEvent(event string, fields ...interface{}) {
 	}, fields...)
 	s.tx.Debug(event, fields...)
 }
+
 func (s *Shell) errorEvent(event string, fields ...interface{}) {
 	fields = append([]interface{}{
 		"device", s.Address,
 	}, fields...)
 	s.tx.Error(event, fields...)
 }
+
 func (s *Shell) infoEvent(event string, fields ...interface{}) {
 	fields = append([]interface{}{
 		"device", s.Address,
 	}, fields...)
 	s.tx.Info(event, fields...)
 }
+
 func (s *Shell) noticeEvent(event string, fields ...interface{}) {
 	fields = append([]interface{}{
 		"device", s.Address,
@@ -68,12 +71,12 @@ func (s *Shell) noticeEvent(event string, fields ...interface{}) {
 	s.tx.Notice(event, fields...)
 }
 
-// Shell starts a remote shell
-func (opts Options) Shell(ctx context.Context) (*Shell, error) {
-	cmd := opts.buildCommand("shell")
+// Shell starts a remote shell.
+func (o Options) Shell(ctx context.Context) (*Shell, error) {
+	cmd := o.buildCommand("shell")
 
 	s := &Shell{
-		Address: opts.Address,
+		Address: o.Address,
 		tx:      elog.TxFromContext(ctx),
 	}
 	s.stdin, _ = cmd.StdinPipe()
@@ -100,16 +103,16 @@ func (opts Options) Shell(ctx context.Context) (*Shell, error) {
 		return nil, errors.WithMessage(err, "error waiting for shell prompt")
 	}
 	// TODO(betawaffle): Add a finalizer to ensure we don't leak?
-	// TODO(mmlb): finalizers are not guranteed to be invoked, figure out a different way to ensure no leaks
+	// TODO(mmlb): finalizers are not guaranteed to be invoked, figure out a different way to ensure no leaks
 	return s, nil
 }
 
-// Close stops the remote shell
+// Close stops the remote shell.
 func (s *Shell) Close() error {
 	return s.Run("quit")
 }
 
-// Run executes a command on the remote shell
+// Run executes a command on the remote shell.
 func (s *Shell) Run(cmd string) (err error) {
 	s.mu.Lock()
 	s.last = cmd
@@ -127,7 +130,7 @@ func (s *Shell) Run(cmd string) (err error) {
 	return s.waitForPrompt()
 }
 
-// LastStatus returns the previous power status
+// LastStatus returns the previous power status.
 func (s *Shell) LastStatus() power.Status {
 	s.mu.Lock()
 	status := s.status
@@ -225,7 +228,7 @@ func (s *Shell) takeErr() error {
 	}
 	switch len(err.Errors) {
 	case 1:
-		if err.Errors[0] == ErrChannelCipherSuites {
+		if errors.Is(err.Errors[0], ErrChannelCipherSuites) {
 			// ignore cipher suites error, ipmitool sends this even though it successfully downgrades
 			return nil
 		}

--- a/server/httpsvr/drivers/racadm/bmc.go
+++ b/server/httpsvr/drivers/racadm/bmc.go
@@ -27,7 +27,7 @@ var bmcActions = map[bmc.Action]string{
 	bmc.WarmReset: "soft",
 }
 
-// BMC runs actions on the BMC
+// BMC runs actions on the BMC.
 func (s *Shell) BMC(action bmc.Action) error {
 	arg, ok := bmcActions[action]
 	if !ok {

--- a/server/httpsvr/drivers/racadm/boot.go
+++ b/server/httpsvr/drivers/racadm/boot.go
@@ -36,7 +36,7 @@ var dell2Devices = map[string]boot.Device{
 	"BIOS":   boot.ForceBIOS,
 }
 
-// SetBootOptions sets boot options
+// SetBootOptions sets boot options.
 func (s *Shell) SetBootOptions(opts boot.Options) error {
 	device, ok := devices[opts.Device]
 	if !ok {
@@ -50,15 +50,16 @@ func (s *Shell) SetBootOptions(opts boot.Options) error {
 	}
 
 	cmd := "racadm set idrac.serverboot.firstbootdevice" + " " + device
-	err := s.Run(cmd)
-	if err != nil {
+
+	if err := s.Run(cmd); err != nil {
 		return errors.WithMessage(err, "failure setting idrac.serverboot.firstbootdevice")
 	}
+
 	cmd = "racadm set idrac.serverboot.bootonce" + " " + bootonce
 	return s.Run(cmd)
 }
 
-// BootOptions returns the configured boot options
+// BootOptions returns the configured boot options.
 func (s *Shell) BootOptions() (boot.Device, bool, error) {
 	devLine, err := s.Output("racadm get idrac.serverboot.firstbootdevice")
 	if err != nil {

--- a/server/httpsvr/drivers/racadm/lan.go
+++ b/server/httpsvr/drivers/racadm/lan.go
@@ -6,7 +6,6 @@ package racadm
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/tinkerbell/pbnj/server/httpsvr/interfaces/bmc"
 )
 
@@ -17,11 +16,11 @@ var lanIPSources = map[bmc.IPSource]string{
 
 // idrac.ipv4
 
-// SetIPSource sets ip configuration method
+// SetIPSource sets ip configuration method.
 func (s *Shell) SetIPSource(source bmc.IPSource) error {
 	arg, ok := lanIPSources[source]
 	if !ok {
-		return errors.New(fmt.Sprintf("ip source %q not supported by racadm driver", source))
+		return fmt.Errorf("ip source %q not supported by racadm driver", source)
 	}
 
 	return s.Run("racadm set idrac.ipv4.dhcpenable" + " " + arg)

--- a/server/httpsvr/drivers/racadm/logging.go
+++ b/server/httpsvr/drivers/racadm/logging.go
@@ -4,6 +4,6 @@
 package racadm
 
 const (
-	// VerboseDebug enables verbose/debug logging
+	// VerboseDebug enables verbose/debug logging.
 	VerboseDebug = false
 )

--- a/server/httpsvr/drivers/racadm/options.go
+++ b/server/httpsvr/drivers/racadm/options.go
@@ -3,14 +3,14 @@
 
 package racadm
 
-// Options are the options racadm accepts
+// Options are the options racadm accepts.
 type Options struct {
 	Address  string
 	Username string
 	Password string
 }
 
-// NewOptions returns an Options struct with the values provided set
+// NewOptions returns an Options struct with the values provided set.
 func NewOptions(addr, user, pass string) Options {
 	return Options{
 		Address:  addr,

--- a/server/httpsvr/drivers/racadm/power.go
+++ b/server/httpsvr/drivers/racadm/power.go
@@ -32,7 +32,7 @@ var powerActions = map[power.Action]string{
 	power.Reset:    "hardreset",
 }
 
-// Power sets the power state
+// Power sets the power state.
 func (s *Shell) Power(action power.Action) error {
 	if action == power.NoAction {
 		return nil
@@ -47,7 +47,7 @@ func (s *Shell) Power(action power.Action) error {
 	return s.Run("racadm serveraction" + " " + arg)
 }
 
-// PowerStatus returns the power state
+// PowerStatus returns the power state.
 func (s *Shell) PowerStatus() (power.Status, error) {
 	out, err := s.Output("racadm get system.power.status")
 	if err != nil {
@@ -67,7 +67,7 @@ func (s *Shell) PowerStatus() (power.Status, error) {
 	return status, err
 }
 
-// LastStatus returns the previous power status
+// LastStatus returns the previous power status.
 func (s *Shell) LastStatus() power.Status {
 	s.lock.RLock()
 	defer s.lock.RUnlock()

--- a/server/httpsvr/drivers/racadm/shell.go
+++ b/server/httpsvr/drivers/racadm/shell.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// Shell represents an open remote shell
+// Shell represents an open remote shell.
 type Shell struct {
 	Address string
 	tx      *evlog.Tx
@@ -30,12 +30,14 @@ func (s *Shell) debugEvent(event string, fields ...interface{}) {
 	}, fields...)
 	s.tx.Debug(event, fields...)
 }
+
 func (s *Shell) errorEvent(event string, fields ...interface{}) {
 	fields = append([]interface{}{
 		"device", s.Address,
 	}, fields...)
 	s.tx.Error(event, fields...)
 }
+
 func (s *Shell) infoEvent(event string, fields ...interface{}) {
 	fields = append([]interface{}{
 		"device", s.Address,
@@ -43,7 +45,7 @@ func (s *Shell) infoEvent(event string, fields ...interface{}) {
 	s.tx.Info(event, fields...)
 }
 
-func (opts Options) AuthKeyboardInteractive(user, instruction string, questions []string, echos []bool) ([]string, error) {
+func (opts Options) AuthKeyboardInteractive(_, _ string, questions []string, _ []bool) ([]string, error) {
 	answers := make([]string, len(questions))
 	for i := range answers {
 		answers[i] = opts.Password
@@ -52,7 +54,7 @@ func (opts Options) AuthKeyboardInteractive(user, instruction string, questions 
 	return answers, nil
 }
 
-// Shell starts a remote shell
+// Shell starts a remote shell.
 func (opts Options) Shell(ctx context.Context) (*Shell, error) {
 	s := &Shell{
 		Address: opts.Address,
@@ -79,12 +81,12 @@ func (opts Options) Shell(ctx context.Context) (*Shell, error) {
 	return s, nil
 }
 
-// Close stops the remote shell
+// Close stops the remote shell.
 func (s *Shell) Close() error {
 	return s.client.Close()
 }
 
-// Run executes a command on the remote shell
+// Run executes a command on the remote shell.
 func (s *Shell) Run(cmd string) error {
 	var err error
 	defer s.tx.Trace("run_racadm_cmd", "device", s.Address, "cmd", cmd).Stop(&err)
@@ -108,14 +110,14 @@ func (s *Shell) Run(cmd string) error {
 	}
 
 	s.infoEvent("output", "out", out)
-	if strings.HasPrefix("ERROR: ", out) {
+	if strings.HasPrefix(out, "ERROR: ") {
 		return errors.New(out)
 	}
 
 	return err
 }
 
-// Output executes a command on the remote shell and returns any output
+// Output executes a command on the remote shell and returns any output.
 func (s *Shell) Output(cmd string) (string, error) {
 	var err error
 	defer s.tx.Trace("run_racadm_cmd", "device", s.Address, "cmd", cmd).Stop(&err)

--- a/server/httpsvr/evlog/evlog.go
+++ b/server/httpsvr/evlog/evlog.go
@@ -10,17 +10,17 @@ import (
 	"github.com/tinkerbell/pbnj/server/httpsvr/reqid"
 )
 
-// Log embeds a Logger
+// Log embeds a Logger.
 type Log struct {
 	logger log.Logger
 }
 
-// New instantiates a new Log
+// New instantiates a new Log.
 func New(logger log.Logger) *Log {
 	return &Log{logger: logger.AddCallerSkip(1)}
 }
 
-// TxFromContext returns a new Tx, using the id from the provided context
+// TxFromContext returns a new Tx, using the id from the provided context.
 func (l *Log) TxFromContext(ctx context.Context) *Tx {
 	return &Tx{l: l, ID: reqid.FromContext(ctx)}
 }

--- a/server/httpsvr/evlog/trace.go
+++ b/server/httpsvr/evlog/trace.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// Trace is used for detailed tracing of events
+// Trace is used for detailed tracing of events.
 type Trace struct {
 	tx Tx
 
@@ -19,7 +19,7 @@ type Trace struct {
 	fields []interface{}
 }
 
-// Stop records the time, along with any non-nil error
+// Stop records the time, along with any non-nil error.
 func (t *Trace) Stop(err *error) {
 	t.end = time.Now()
 

--- a/server/httpsvr/evlog/tx.go
+++ b/server/httpsvr/evlog/tx.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// Tx is used for loggin an event
+// Tx is used for loggin an event.
 type Tx struct {
 	l      *Log
 	ID     string
@@ -16,52 +16,52 @@ type Tx struct {
 }
 
 func fields2KVP(fields []interface{}) []string {
-	var kvp = make([]string, 0, len(fields)/2)
-	for i := 0; i < len(fields); i = i + 2 {
+	kvp := make([]string, 0, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
 		pair := fmt.Sprintf("%s=%s", fields[i], fields[i+1])
 		kvp = append(kvp, pair)
 	}
 	return kvp
 }
 
-// With returns
+// With returns.
 func (tx *Tx) With(fields ...interface{}) *Tx {
 	n := *tx
 	n.fields = fields
 	return &n
 }
 
-// Panic is a helper function to log a CRITICAL event
+// Panic is a helper function to log a CRITICAL event.
 func (tx *Tx) Panic(event string, fields ...interface{}) {
 	tx.l.logger.With(fields...).With(tx.getFields()...).With("event", event).Panic()
 }
 
-// Error is a helper function to log an error
+// Error is a helper function to log an error.
 func (tx *Tx) Error(event string, fields ...interface{}) {
 	tx.l.logger.With(fields...).With(tx.getFields()...).With("event", event).Error()
 }
 
-// Warning is a helper function to log a warning
+// Warning is a helper function to log a warning.
 func (tx *Tx) Warning(event string, fields ...interface{}) {
 	tx.l.logger.With(fields...).With(tx.getFields()...).With("event", event).Warning()
 }
 
-// Notice is a helper function to log a notice
+// Notice is a helper function to log a notice.
 func (tx *Tx) Notice(event string, fields ...interface{}) {
 	tx.l.logger.With(fields...).With(tx.getFields()...).With("event", event).Notice()
 }
 
-// Info is a helper function to log an info message
+// Info is a helper function to log an info message.
 func (tx *Tx) Info(event string, fields ...interface{}) {
 	tx.l.logger.With(fields...).With(tx.getFields()...).With("event", event).Info()
 }
 
-// Debug is a helper function to log a debug message
+// Debug is a helper function to log a debug message.
 func (tx *Tx) Debug(event string, fields ...interface{}) {
 	tx.l.logger.With(fields...).With(tx.getFields()...).With("event", event).Debug()
 }
 
-// Trace is a helper function to log a trace message
+// Trace is a helper function to log a trace message.
 func (tx *Tx) Trace(event string, fields ...interface{}) *Trace {
 	t := &Trace{
 		start:  time.Now(),

--- a/server/httpsvr/interfaces/bmc/bmc.go
+++ b/server/httpsvr/interfaces/bmc/bmc.go
@@ -15,15 +15,15 @@ var (
 	factories = make(map[string]DriverFactory)
 )
 
-// Action is used to denote the available power actions
+// Action is used to denote the available power actions.
 type Action string
 
 const (
-	// NoAction is a NOP
+	// NoAction is a NOP.
 	NoAction = Action("")
-	// ColdReset does a cold reset
+	// ColdReset does a cold reset.
 	ColdReset = Action("reset_cold")
-	// WarmReset does a warm reset
+	// WarmReset does a warm reset.
 	WarmReset = Action("reset_warm")
 )
 
@@ -31,13 +31,13 @@ func SetupLogging(l log.Logger) {
 	logger = l.Package("bmc")
 }
 
-// ActionsBySlug is a reverse mapping of Action types
+// ActionsBySlug is a reverse mapping of Action types.
 var ActionsBySlug = map[string]Action{
 	"reset_cold": ColdReset,
 	"reset_warm": WarmReset,
 }
 
-// UnmarshalText unmarshals an Action from a textual representation
+// UnmarshalText unmarshals an Action from a textual representation.
 func (a *Action) UnmarshalText(text []byte) error {
 	if v, ok := ActionsBySlug[string(text)]; ok {
 		*a = v
@@ -46,7 +46,7 @@ func (a *Action) UnmarshalText(text []byte) error {
 	return errors.Errorf("unsupported bmc action: %q", text)
 }
 
-// Driver is the interface to control BMCs
+// Driver is the interface to control BMCs.
 type Driver interface {
 	BMC(action Action) error
 	SetIPSource(source IPSource) error
@@ -54,10 +54,10 @@ type Driver interface {
 	Close() error
 }
 
-// DriverFactory is used to instantiate a new Driver
+// DriverFactory is used to instantiate a new Driver.
 type DriverFactory func(context.Context, DriverOptions) (Driver, error)
 
-// DriverOptions contain the basic options needed to connect to device
+// DriverOptions contain the basic options needed to connect to device.
 type DriverOptions struct {
 	Address  string
 	Username string
@@ -66,7 +66,7 @@ type DriverOptions struct {
 	Cipher   int
 }
 
-// NewDriver instantiates a new driver by calling the registered factory function
+// NewDriver instantiates a new driver by calling the registered factory function.
 func NewDriver(ctx context.Context, name string, opts DriverOptions) (Driver, error) {
 	factory, ok := factories[name]
 	if !ok {
@@ -75,7 +75,7 @@ func NewDriver(ctx context.Context, name string, opts DriverOptions) (Driver, er
 	return factory(ctx, opts)
 }
 
-// RegisterDriver is called by implementations in order to register their factory function for each device they can control
+// RegisterDriver is called by implementations in order to register their factory function for each device they can control.
 func RegisterDriver(factory DriverFactory, driver string) {
 	if _, ok := factories[driver]; ok {
 		logger.Panicf("power driver %q already registered!", driver)

--- a/server/httpsvr/interfaces/bmc/http.go
+++ b/server/httpsvr/interfaces/bmc/http.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tinkerbell/pbnj/server/httpsvr/util"
 )
 
-// NewDriverFromGinContext creates a new Driver using info in the http request
+// NewDriverFromGinContext creates a new Driver using info in the http request.
 func NewDriverFromGinContext(c *gin.Context) Driver {
 	driverType := util.FindDriver(c)
 	driverOpts := DriverOptions{

--- a/server/httpsvr/interfaces/bmc/lan.go
+++ b/server/httpsvr/interfaces/bmc/lan.go
@@ -5,23 +5,23 @@ package bmc
 
 import "github.com/pkg/errors"
 
-// IPSource denotes the types of ip configurations
+// IPSource denotes the types of ip configurations.
 type IPSource string
 
 const (
-	// IPFromDHCP denotes ip via dhcp configuration
+	// IPFromDHCP denotes ip via dhcp configuration.
 	IPFromDHCP = IPSource("dhcp")
-	// StaticIP denotes ip via static configuration
+	// StaticIP denotes ip via static configuration.
 	StaticIP = IPSource("static")
 )
 
-// IPSourceBySlug is a reverse mapping of strings to IPSource
+// IPSourceBySlug is a reverse mapping of strings to IPSource.
 var IPSourceBySlug = map[string]IPSource{
 	"dhcp":   IPFromDHCP,
 	"static": StaticIP,
 }
 
-// UnmarshalText unmarshals an IPSource from a textual representation
+// UnmarshalText unmarshals an IPSource from a textual representation.
 func (s *IPSource) UnmarshalText(text []byte) error {
 	if v, ok := IPSourceBySlug[string(text)]; ok {
 		*s = v

--- a/server/httpsvr/interfaces/boot/boot.go
+++ b/server/httpsvr/interfaces/boot/boot.go
@@ -15,17 +15,17 @@ var (
 	factories = make(map[string]DriverFactory)
 )
 
-// Device describe bootable devices
+// Device describe bootable devices.
 type Device string
 
 const (
-	// DefaultDevice is the default boot device
+	// DefaultDevice is the default boot device.
 	DefaultDevice = Device("default")
-	// ForcePXE is used to configure pxe as the boot device
+	// ForcePXE is used to configure pxe as the boot device.
 	ForcePXE = Device("pxe")
-	// ForceDisk is used to configure disk as the boot device
+	// ForceDisk is used to configure disk as the boot device.
 	ForceDisk = Device("disk")
-	// ForceBIOS is used to configure bios as the boot device
+	// ForceBIOS is used to configure bios as the boot device.
 	ForceBIOS = Device("bios")
 )
 
@@ -33,17 +33,17 @@ func SetupLogging(l log.Logger) {
 	logger = l.Package("boot")
 }
 
-// Driver is the interface to control boot
+// Driver is the interface to control boot.
 type Driver interface {
 	SetBootOptions(Options) error
 
 	Close() error
 }
 
-// DriverFactory is used to instantiate a new Driver
+// DriverFactory is used to instantiate a new Driver.
 type DriverFactory func(context.Context, DriverOptions) (Driver, error)
 
-// DriverOptions contain the basic options needed to connect to device
+// DriverOptions contain the basic options needed to connect to device.
 type DriverOptions struct {
 	Address  string
 	Username string
@@ -52,7 +52,7 @@ type DriverOptions struct {
 	Cipher   int
 }
 
-// Options contain values relevant for boot actions
+// Options contain values relevant for boot actions.
 type Options struct {
 	// Device is the boot device to force.
 	Device Device `json:"device" binding:"required"`
@@ -64,7 +64,7 @@ type Options struct {
 	EFI bool `json:"efi,omitempty"`
 }
 
-// NewDriver instantiates a new driver by calling the registered factory function
+// NewDriver instantiates a new driver by calling the registered factory function.
 func NewDriver(ctx context.Context, name string, opts DriverOptions) (Driver, error) {
 	factory, ok := factories[name]
 	if !ok {
@@ -73,7 +73,7 @@ func NewDriver(ctx context.Context, name string, opts DriverOptions) (Driver, er
 	return factory(ctx, opts)
 }
 
-// RegisterDriver is called by implementations in order to register their factory function for each device they can control
+// RegisterDriver is called by implementations in order to register their factory function for each device they can control.
 func RegisterDriver(factory DriverFactory, driver string) {
 	if _, ok := factories[driver]; ok {
 		logger.Panicf("boot driver %q already registered!", driver)

--- a/server/httpsvr/interfaces/boot/http.go
+++ b/server/httpsvr/interfaces/boot/http.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tinkerbell/pbnj/server/httpsvr/util"
 )
 
-// NewDriverFromGinContext creates a new Driver using info in the http request
+// NewDriverFromGinContext creates a new Driver using info in the http request.
 func NewDriverFromGinContext(c *gin.Context) Driver {
 	driverType := util.FindDriver(c)
 	driverOpts := DriverOptions{

--- a/server/httpsvr/interfaces/power/http.go
+++ b/server/httpsvr/interfaces/power/http.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tinkerbell/pbnj/server/httpsvr/util"
 )
 
-// NewDriverFromGinContext creates a new Driver using info in the http request
+// NewDriverFromGinContext creates a new Driver using info in the http request.
 func NewDriverFromGinContext(c *gin.Context) Driver {
 	driverType := util.FindDriver(c)
 	driverOpts := DriverOptions{

--- a/server/httpsvr/interfaces/power/power.go
+++ b/server/httpsvr/interfaces/power/power.go
@@ -18,7 +18,7 @@ var (
 	factories = make(map[string]DriverFactory)
 )
 
-// Action is the type for available actions
+// Action is the type for available actions.
 type Action string
 
 func SetupLogging(l log.Logger) {
@@ -27,19 +27,19 @@ func SetupLogging(l log.Logger) {
 }
 
 const (
-	// NoAction is a Nop
+	// NoAction is a Nop.
 	NoAction = Action("")
-	// TurnOn will power up the device
+	// TurnOn will power up the device.
 	TurnOn = Action("turn_on")
-	// SoftOff will perform a soft-shutdown (usually through OS via ACPI)
+	// SoftOff will perform a soft-shutdown (usually through OS via ACPI).
 	SoftOff = Action("soft_off")
-	// HardOff will power off the device without informing the OS
+	// HardOff will power off the device without informing the OS.
 	HardOff = Action("hard_off")
-	// Reset will perform a hard reset without informing the OS
+	// Reset will perform a hard reset without informing the OS.
 	Reset = Action("reset")
 )
 
-// Driver is the interface to control power
+// Driver is the interface to control power.
 type Driver interface {
 	PowerStatus() (Status, error)
 	Power(action Action) error
@@ -49,10 +49,10 @@ type Driver interface {
 	Close() error
 }
 
-// DriverFactory is used to instantiate a new Driver
+// DriverFactory is used to instantiate a new Driver.
 type DriverFactory func(context.Context, DriverOptions) (Driver, error)
 
-// DriverOptions contain the basic options needed to connect to device
+// DriverOptions contain the basic options needed to connect to device.
 type DriverOptions struct {
 	Address  string
 	Username string
@@ -61,7 +61,7 @@ type DriverOptions struct {
 	Cipher   int
 }
 
-// Options contain time values relevant for power actions
+// Options contain time values relevant for power actions.
 type Options struct {
 	SoftTimeout    time.Duration
 	OffTimeout     time.Duration
@@ -70,7 +70,7 @@ type Options struct {
 	IgnoreRunError bool
 }
 
-// DefaultOptions are the default times for power actions
+// DefaultOptions are the default times for power actions.
 var DefaultOptions = Options{
 	SoftTimeout:    30 * time.Second,
 	OffDuration:    3 * time.Second,
@@ -79,19 +79,19 @@ var DefaultOptions = Options{
 	IgnoreRunError: false,
 }
 
-// Status is the type for reporting power status
+// Status is the type for reporting power status.
 type Status string
 
 const (
-	// AnyStatus is a fallback for unknown status
+	// AnyStatus is a fallback for unknown status.
 	AnyStatus = Status("")
-	// Off is returned when the device is powered off
+	// Off is returned when the device is powered off.
 	Off = Status("off")
-	// On is returned when the device is powered on
+	// On is returned when the device is powered on.
 	On = Status("on")
 )
 
-// NewDriver instantiates a new driver by calling the registered factory function
+// NewDriver instantiates a new driver by calling the registered factory function.
 func NewDriver(ctx context.Context, name string, opts DriverOptions) (Driver, error) {
 	factory, ok := factories[name]
 	if !ok {
@@ -100,7 +100,7 @@ func NewDriver(ctx context.Context, name string, opts DriverOptions) (Driver, er
 	return factory(ctx, opts)
 }
 
-// RegisterDriver is called by implementations in order to register their factory function for each device they can control
+// RegisterDriver is called by implementations in order to register their factory function for each device they can control.
 func RegisterDriver(factory DriverFactory, driver string) {
 	if _, ok := factories[driver]; ok {
 		logger.Panicf("power driver %q already registered!", driver)

--- a/server/httpsvr/log/log.go
+++ b/server/httpsvr/log/log.go
@@ -16,7 +16,7 @@ var (
 	logLevel = zap.LevelFlag("log-level", zap.InfoLevel, "Log level, one of FATAL, PANIC, DPANIC, ERROR, WARN, INFO, or DEBUG")
 )
 
-// Logger is a wrapper around zap.SugaredLogger
+// Logger is a wrapper around zap.SugaredLogger.
 type Logger struct {
 	*zap.SugaredLogger
 }

--- a/server/httpsvr/reqid/reqid.go
+++ b/server/httpsvr/reqid/reqid.go
@@ -20,15 +20,13 @@ type id string
 // It is unexported; clients use reqid.NewContext and reqid.FromContext instead of using this key directly.
 const key = id("reqid")
 
-var (
-	logger log.Logger
-)
+var logger log.Logger
 
 func SetupLogging(l log.Logger) {
 	logger = l.Package("reqid")
 }
 
-// WithID returns a new Context that carries value id
+// WithID returns a new Context that carries value id.
 func WithID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, key, id)
 }
@@ -58,7 +56,7 @@ func FromContext(ctx context.Context) string {
 	return ""
 }
 
-// New creates a new id
+// New creates a new id.
 func New() string {
 	buf := make([]byte, 16)
 	if _, err := rand.Read(buf); err != nil {

--- a/server/httpsvr/server.go
+++ b/server/httpsvr/server.go
@@ -38,7 +38,7 @@ func cleanup() {
 	}
 }
 
-// RunHTTPServer runs PBnJ v1 HTTP server
+// RunHTTPServer runs PBnJ v1 HTTP server.
 func RunHTTPServer() {
 	flag.Parse()
 
@@ -46,7 +46,14 @@ func RunHTTPServer() {
 	if err != nil {
 		panic(err)
 	}
-	defer sync() // nolint
+
+	logger = logger.Package("main")
+	defer func() {
+		err := sync()
+		if err != nil {
+			logger.Errorf("logger sync failed: %v", err)
+		}
+	}()
 
 	api.SetupLogging(logger)
 	ipmitool.SetupLogging(logger)
@@ -55,7 +62,6 @@ func RunHTTPServer() {
 	reqid.SetupLogging(logger)
 	go cleanup()
 
-	logger = logger.Package("main")
 	if err := api.Serve(listenAddr, GitRev); err != nil {
 		logger.Fatalw("error serving api", "error", err)
 	}

--- a/server/httpsvr/util/util.go
+++ b/server/httpsvr/util/util.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// FindDriver finds the driver type given a manufacturer, defaulting to ipmitool
+// FindDriver finds the driver type given a manufacturer, defaulting to ipmitool.
 func FindDriver(c *gin.Context) string {
 	manufacturer := c.Request.Header.Get("X-DEVICE-MANUFACTURER")
 	if manufacturer == "dell" {

--- a/test/main.go
+++ b/test/main.go
@@ -29,7 +29,11 @@ var (
 func main() {
 	fmt.Println("PBnJ Functional Testing")
 	flag.Parse()
-	cfgData.Config(*cfg)
+	if err := cfgData.Config(*cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "config error: %v", err)
+		os.Exit(1)
+	}
+
 	if cfgData.Server.Port == "" && cfgData.Server.URL == "" {
 		// start a local internal server
 		go func() {
@@ -47,7 +51,7 @@ func main() {
 	runner.RunTests(logger, cfgData)
 }
 
-// Returns an int >= min, < max
+// Returns an int >= min, < max.
 func randomInt(min, max int) string {
 	rand.Seed(time.Now().UnixNano())
 	return strconv.Itoa(rand.Intn(max-min+1) + min)

--- a/test/runner/common.go
+++ b/test/runner/common.go
@@ -1,37 +1,35 @@
 package runner
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 
 	"gopkg.in/yaml.v2"
 )
 
-// ConfigFile is the config file
+// ConfigFile is the config file.
 type ConfigFile struct {
 	Server Server `yaml:"server"`
 	Data   `yaml:",inline"`
 }
 
-// Server is the connection details
+// Server is the connection details.
 type Server struct {
 	URL  string `yaml:"url"`
 	Port string `yaml:"port"`
 }
 
-// Data of BMC resources
+// Data of BMC resources.
 type Data struct {
 	Resources []Resource `yaml:"resources"`
 }
 
-// UseCases classes with names
+// UseCases classes with names.
 type UseCases struct {
 	Power  []string `yaml:"power"`
 	Device []string `yaml:"device"`
 }
 
-// Resource details of a single BMC
+// Resource details of a single BMC.
 type Resource struct {
 	IP       string   `yaml:"ip"`
 	Username string   `yaml:"username"`
@@ -40,29 +38,11 @@ type Resource struct {
 	UseCases UseCases `yaml:"useCases"`
 }
 
-// Config for the resources file
-func (c *ConfigFile) Config(name string) {
-	err := c.parseConfig(name)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
-}
-
-// parseConfig reads and validates a config
-func (c *ConfigFile) parseConfig(name string) error {
+// Config for the resources file.
+func (c *ConfigFile) Config(name string) error {
 	config, err := ioutil.ReadFile(name)
 	if err != nil {
 		return err
 	}
-	err = yaml.Unmarshal(config, &c)
-	if err != nil {
-		return err
-	}
-
-	return c.validateConfig()
-}
-
-func (c *ConfigFile) validateConfig() error {
-	return nil
+	return yaml.Unmarshal(config, &c)
 }

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -35,7 +35,7 @@ type testResource struct {
 
 type dataObject map[string]testResource
 
-// RunTests actions against BMCs
+// RunTests actions against BMCs.
 func RunTests(t logr.Logger, cfgData ConfigFile) {
 	resources := createTestData(cfgData.Data)
 	for _, rs := range resources {
@@ -133,7 +133,6 @@ func RunTests(t logr.Logger, cfgData ConfigFile) {
 			}
 		COMPLETE:
 			fmt.Printf("============ %v: completed test: %v ============\n", successful, stepName.Want.Description)
-
 		}
 		fmt.Println()
 		fmt.Println("========", "End of tests against:", rs.Host, "========")
@@ -258,50 +257,6 @@ func runBMCCreateUserClient(in testResource, action *v1.CreateUserRequest, s Ser
 		},
 	}
 	resp, err := v1Client.BMCCreateUser(ctx, client, taskClient, inRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
-}
-
-func runBMCUpdateUserClient(in testResource, action *v1.UpdateUserRequest, s Server) (*v1.StatusResponse, error) { // nolint
-	var opts []grpc.DialOption
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	opts = append(opts, grpc.WithInsecure())
-	conn, err := grpc.Dial(s.URL+":"+s.Port, opts...)
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-	client := v1.NewBMCClient(conn)
-	taskClient := v1.NewTaskClient(conn)
-
-	inRequest := &v1.UpdateUserRequest{
-		Authn: &v1.Authn{
-			Authn: &v1.Authn_DirectAuthn{
-				DirectAuthn: &v1.DirectAuthn{
-					Host: &v1.Host{
-						Host: in.Host,
-					},
-					Username: in.Username,
-					Password: in.Password,
-				},
-			},
-		},
-		Vendor: &v1.Vendor{
-			Name: in.Vendor,
-		},
-		UserCreds: &v1.UserCreds{
-			Username: action.UserCreds.Username,
-			Password: action.UserCreds.Password,
-			UserRole: action.UserCreds.UserRole,
-		},
-	}
-	resp, err := v1Client.BMCUpdateUser(ctx, client, taskClient, inRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/test/runner/tests.go
+++ b/test/runner/tests.go
@@ -11,17 +11,11 @@ var (
 	powerRequestOFF    = v1.PowerAction_POWER_ACTION_OFF
 	powerRequestSTATUS = v1.PowerAction_POWER_ACTION_STATUS
 	powerRequestCYCLE  = v1.PowerAction_POWER_ACTION_CYCLE
-	//powerRequestRESET   = v1.PowerAction_POWER_ACTION_RESET
-	//powerRequestHARDOFF = v1.PowerAction_POWER_ACTION_HARDOFF
-	//deviceRequestNONE   = v1.BootDevice_BOOT_DEVICE_NONE
-	deviceRequestBIOS = v1.BootDevice_BOOT_DEVICE_BIOS
-	//deviceRequestDISK   = v1.BootDevice_BOOT_DEVICE_DISK
-	//deviceRequestCDROM  = v1.BootDevice_BOOT_DEVICE_CDROM
-	deviceRequestPXE = v1.BootDevice_BOOT_DEVICE_PXE
-	lookup           = map[string]map[string]expected{
+	deviceRequestBIOS  = v1.BootDevice_BOOT_DEVICE_BIOS
+	deviceRequestPXE   = v1.BootDevice_BOOT_DEVICE_PXE
+	lookup             = map[string]map[string]expected{
 		"happyTests":    happyTests,
 		"userMgmtTests": userMgmtTests,
-		//"notIdentifiableTests": notIdentifiableTests,
 	}
 	happyTests = map[string]expected{
 		"1 power off": {
@@ -126,9 +120,6 @@ var (
 				Messages:    []string{"working on power POWER_ACTION_STATUS", "connected to BMC", "power POWER_ACTION_STATUS complete"},
 			},
 		},
-
-		//"power hardoff": {Action: &PowerRequest_HARDOFF, Want: notImplementedWant("HARD OFF")},
-		//"power reset":   {Action: &PowerRequest_RESET, Want: notImplementedWant("RESET")},
 	}
 	userMgmtTests = map[string]expected{
 		"1 create a user": {


### PR DESCRIPTION
## Description

This PR adds `lint-install` rules for Go, Shell, and Dockerfile, as well as implements the fixes raised by them.

## Why is this needed

Fixes #9

## How Has This Been Tested?

* `make test`
* `make lint`
* `make image`
* `make build`
* `make run-image`
* `make run-server`

## What lint checks were addressed?

## Dockerfile

```
Dockerfile:18 DL3003 warning: Use WORKDIR to switch to a directory
Dockerfile:18 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
Dockerfile:18 SC2086 info: Double quote to prevent globbing and word splitting.
Dockerfile:52 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
```

## Go

```
client/client.go:10:80: Comment should end in a period (godot)
// MachinePower executes a power action against the server and retrieves status
                                                                               ^
client/client.go:28: unnecessary trailing newline (whitespace)

}
client/client.go:31:58: Comment should end in a period (godot)
// MachineBootDev sets the next boot device for a machine
                                                         ^
client/client.go:51:36: Comment should end in a period (godot)
// BMCCreateUser creates a BMC user
                                   ^
client/client.go:71:36: Comment should end in a period (godot)
// BMCUpdateUser updates a BMC user
                                   ^
client/client.go:91:36: Comment should end in a period (godot)
// BMCDeleteUser updates a BMC user
                                   ^
cmd/client.go:7:43: Comment should end in a period (godot)
// clientCmd represents the server command
                                          ^
cmd/machine.go:15:44: Comment should end in a period (godot)
// machineCmd represents the server command
                                           ^
cmd/machine.go:34:21: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
		defer zlog.Sync() // nolint
		                  ^
cmd/root.go:20:75: Comment should end in a period (godot)
// rootCmd represents the base command when called without any subcommands
                                                                          ^
cmd/root.go:30:52: Comment should end in a period (godot)
// NewRootCmd is used for testing to run the server
                                                   ^
cmd/root.go:68:101: Comment should end in a period (godot)
// Bind each cobra flag to its associated viper configuration (config file and environment variable)
                                                                                                    ^
cmd/server.go:43:44: Comment should end in a period (godot)
	// serverCmd represents the server command
	                                          ^
cmd/server.go:61:22: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
			defer zlog.Sync() // nolint
			                  ^
cmd/server.go:124:2: ifElseChain: rewrite if-else to switch statement (gocritic)
	if hsKey != "" {
	^
pkg/healthcheck/healthcheck.go:11:31: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
                              ^
pkg/healthcheck/healthcheck.go:17:31: unused-parameter: parameter 'req' seems to be unused, consider removing or renaming it as _ (revive)
func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
                              ^
pkg/http/handlers.go:22:63: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func (h *HTTPServer) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
                                                              ^
pkg/http/handlers.go:30:57: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func (h *HTTPServer) handleReady(w http.ResponseWriter, r *http.Request) {
                                                        ^
pkg/http/handlers.go:38:56: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
func (h *HTTPServer) handleLive(w http.ResponseWriter, r *http.Request) {
                                                       ^
pkg/http/http.go:11:6: exported: type name will be used as http.HTTPServer by other packages, and that stutters; consider calling this Server (revive)
type HTTPServer struct {
     ^
pkg/logging/logging.go:9:58: Comment should end in a period (godot)
// Logger represent common interface for logging function
                                                         ^
pkg/oob/oob.go:10:34: Comment should end in a period (godot)
// PowerSetter management methods
                                 ^
pkg/oob/oob.go:16:50: Comment should end in a period (godot)
// BootDeviceSetter takes care of resetting a BMC
                                                 ^
pkg/oob/oob.go:21:26: Comment should end in a period (godot)
// BMC management methods
                         ^
pkg/oob/oob.go:29:23: Comment should end in a period (godot)
// BMCResetter options
                      ^
pkg/oob/oob.go:36:49: Comment should end in a period (godot)
// SetPower interface function for power actions
                                                ^
pkg/oob/oob.go:58:65: Comment should end in a period (godot)
// SetBootDevice interface function for setting next boot device
                                                                ^
pkg/oob/oob.go:80:33: Comment should end in a period (godot)
// CreateUser interface function
                                ^
pkg/oob/oob.go:102:33: Comment should end in a period (godot)
// UpdateUser interface function
                                ^
pkg/oob/oob.go:124:33: Comment should end in a period (godot)
// DeleteUser interface function
                                ^
pkg/oob/oob.go:146:31: Comment should end in a period (godot)
// ResetBMC interface function
                              ^
pkg/oob/oob_test.go:17:30: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (o *OOBTester) PowerSet(ctx context.Context, action string) (result string, err error) {
                             ^
pkg/oob/oob_test.go:24:35: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (o *OOBTester) BootDeviceSet(ctx context.Context, device string, persistent, efiBoot bool) (result string, err error) {
                                  ^
pkg/oob/oob_test.go:31:30: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (o *OOBTester) BMCReset(ctx context.Context, rType string) (err error) {
                             ^
pkg/oob/oob_test.go:38:32: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (o *OOBTester) CreateUser(ctx context.Context) (err error) {
                               ^
pkg/oob/oob_test.go:45:32: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (o *OOBTester) UpdateUser(ctx context.Context) (err error) {
                               ^
pkg/oob/oob_test.go:52:32: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (o *OOBTester) DeleteUser(ctx context.Context) (err error) {
                               ^
pkg/oob/oob_test.go:88: unnecessary trailing newline (whitespace)

			} else {
pkg/oob/oob_test.go:95: unnecessary trailing newline (whitespace)

		})
pkg/oob/oob_test.go:129: unnecessary trailing newline (whitespace)

			} else {
pkg/oob/oob_test.go:136: unnecessary trailing newline (whitespace)

		})
pkg/repository/repo.go:7:64: Comment should end in a period (godot)
// Actions interface for interacting with the persistence layer
                                                               ^
pkg/repository/repo.go:15:37: Comment should end in a period (godot)
// Record that is stored in the repo
                                    ^
pkg/repository/repo.go:17:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//*v1.StatusResponse
	^
pkg/repository/repo.go:18:2: var-naming: struct field Id should be ID (revive)
	Id          string
	^
pkg/repository/repo.go:27:29: Comment should end in a period (godot)
// Error for all bmc actions
                            ^
pkg/repository/repo.go:38:60: Comment should end in a period (godot)
// StructuredError returns the error struct for convenience
                                                           ^
pkg/task/task.go:9:40: Comment should end in a period (godot)
// Task interface for doing BMC actions
                                       ^
pkg/zaplog/middleware.go:17:24: unused-parameter: parameter 'logger' seems to be unused, consider removing or renaming it as _ (revive)
func UnaryLogRequestID(logger *zap.Logger, requestIDKey, requestIDLogKey string) grpc.UnaryServerInterceptor {
                       ^
pkg/zaplog/zap.go:12:48: Comment should end in a period (godot)
// Logger is a wrapper around zap.SugaredLogger
                                               ^
pkg/zaplog/zap.go:17:55: Comment should end in a period (godot)
// GetContextLogger get and return a logger from a ctx
                                                      ^
pkg/zaplog/zap.go:22:88: Comment should end in a period (godot)
// RegisterLogger returns a logr and a zap logger (needed for use in grpc interceptors)
                                                                                       ^
server/grpcsvr/oob/bmc/bmc.go:16:72: Comment should end in a period (godot)
// Action for making bmc actions on BMCs, implements oob.User interface
                                                                       ^
server/grpcsvr/oob/bmc/bmc.go:25:31: Comment should end in a period (godot)
// Option to add to an Actions
                              ^
server/grpcsvr/oob/bmc/bmc.go:28:46: Comment should end in a period (godot)
// WithLogger adds a logr to an Action struct
                                             ^
server/grpcsvr/oob/bmc/bmc.go:36:68: Comment should end in a period (godot)
// WithStatusMessage adds a status message chan to an Action struct
                                                                   ^
server/grpcsvr/oob/bmc/bmc.go:44:68: Comment should end in a period (godot)
// WithCreateUserRequest adds CreateUserRequest to an Action struct
                                                                   ^
server/grpcsvr/oob/bmc/bmc.go:52:68: Comment should end in a period (godot)
// WithDeleteUserRequest adds DeleteUserRequest to an Action struct
                                                                   ^
server/grpcsvr/oob/bmc/bmc.go:60:68: Comment should end in a period (godot)
// WithUpdateUserRequest adds UpdateUserRequest to an Action struct
                                                                   ^
server/grpcsvr/oob/bmc/bmc.go:68:58: Comment should end in a period (godot)
// WithResetRequest adds ResetRequest to an Action struct
                                                         ^
server/grpcsvr/oob/bmc/bmc.go:76:39: Comment should end in a period (godot)
// NewBMC returns an oob.BMC interface
                                      ^
server/grpcsvr/oob/bmc/bmc.go:89:55: Comment should end in a period (godot)
// NewBMCResetter returns an oob.BMCResetter interface
                                                      ^
server/grpcsvr/oob/bmc/bmc.go:102:41: Comment should end in a period (godot)
// CreateUser functionality for machines
                                        ^
server/grpcsvr/oob/bmc/bmc.go:103: 103-159 lines are duplicate of `server/grpcsvr/oob/bmc/bmc.go:162-218` (dupl)
func (m Action) CreateUser(ctx context.Context) error {
	labels := prometheus.Labels{
		"service": "bmc",
		"action":  "create_user",
	}
	timer := prometheus.NewTimer(metrics.ActionDuration.With(labels))
	defer timer.ObserveDuration()

	var err error
	host, user, password, parseErr := m.ParseAuth(m.CreateUserRequest.Authn)
	if parseErr != nil {
		return parseErr
	}
	creds := m.CreateUserRequest.GetUserCreds()
	base := "creating user: " + creds.GetUsername()
	msg := "working on " + base
	m.SendStatusMessage(msg)

	connections := map[string]interface{}{
		"bmclib": &bmclibUserManagement{
			user:     user,
			password: password,
			host:     host,
			log:      m.Log,
			creds:    creds,
		},
	}

	m.SendStatusMessage("connecting to BMC")
	successfulConnections, ecErr := common.EstablishConnections(ctx, connections)
	if ecErr != nil {
		m.SendStatusMessage("connecting to BMC failed")
		return ecErr
	}
	m.SendStatusMessage("connected to BMC")

	var userAction []oob.BMC
	for _, elem := range successfulConnections {
		conn := connections[elem]
		switch r := conn.(type) {
		case common.Connection:
			defer r.Close(ctx)
		}
		switch r := conn.(type) {
		case oob.BMC:
			userAction = append(userAction, r)
		}
	}
	err = oob.CreateUser(ctx, userAction)
	if err != nil {
		m.SendStatusMessage("error with " + base + ": " + err.Error())
		m.Log.V(0).Info("error with "+base, "error", err.Error())
		return err
	}
	m.SendStatusMessage(base + " complete")
	return nil
}
server/grpcsvr/oob/bmc/bmc.go:142:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/bmc/bmc.go:144:4: defer: prefer not to defer inside loops (revive)
			defer r.Close(ctx)
			^
server/grpcsvr/oob/bmc/bmc.go:146:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/bmc/bmc.go:161:41: Comment should end in a period (godot)
// UpdateUser functionality for machines
                                        ^
server/grpcsvr/oob/bmc/bmc.go:162: 162-218 lines are duplicate of `server/grpcsvr/oob/bmc/bmc.go:103-159` (dupl)
func (m Action) UpdateUser(ctx context.Context) error {
	labels := prometheus.Labels{
		"service": "bmc",
		"action":  "update_user",
	}
	timer := prometheus.NewTimer(metrics.ActionDuration.With(labels))
	defer timer.ObserveDuration()

	var err error
	host, user, password, parseErr := m.ParseAuth(m.UpdateUserRequest.Authn)
	if parseErr != nil {
		return parseErr
	}
	creds := m.UpdateUserRequest.GetUserCreds()
	base := "updating user: " + creds.GetUsername()
	msg := "working on " + base
	m.SendStatusMessage(msg)

	connections := map[string]interface{}{
		"bmclib": &bmclibUserManagement{
			user:     user,
			password: password,
			host:     host,
			log:      m.Log,
			creds:    creds,
		},
	}

	m.SendStatusMessage("connecting to BMC")
	successfulConnections, ecErr := common.EstablishConnections(ctx, connections)
	if ecErr != nil {
		m.SendStatusMessage("connecting to BMC failed")
		return ecErr
	}
	m.SendStatusMessage("connected to BMC")

	var userAction []oob.BMC
	for _, elem := range successfulConnections {
		conn := connections[elem]
		switch r := conn.(type) {
		case common.Connection:
			defer r.Close(ctx)
		}
		switch r := conn.(type) {
		case oob.BMC:
			userAction = append(userAction, r)
		}
	}
	err = oob.UpdateUser(ctx, userAction)
	if err != nil {
		m.SendStatusMessage("error with " + base + ": " + err.Error())
		m.Log.V(0).Info("error with "+base, "error", err.Error())
		return err
	}
	m.SendStatusMessage(base + " complete")
	return nil
}
server/grpcsvr/oob/bmc/bmc.go:201:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/bmc/bmc.go:203:4: defer: prefer not to defer inside loops (revive)
			defer r.Close(ctx)
			^
server/grpcsvr/oob/bmc/bmc.go:205:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/bmc/bmc.go:220:41: Comment should end in a period (godot)
// DeleteUser functionality for machines
                                        ^
server/grpcsvr/oob/bmc/bmc.go:261:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/bmc/bmc.go:263:4: defer: prefer not to defer inside loops (revive)
			defer r.Close(ctx)
			^
server/grpcsvr/oob/bmc/bmc.go:265:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/bmc/bmc.go:280:39: Comment should end in a period (godot)
// BMCReset functionality for machines
                                      ^
server/grpcsvr/oob/bmc/bmc.go:288:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//client.Registry.Drivers = client.Registry.FilterForCompatible(ctx)
	^
server/grpcsvr/oob/bmc/users_bmclib.go:43:38: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibUserManagement) Close(ctx context.Context) {
                                     ^
server/grpcsvr/oob/bmc/users_bmclib.go:47:43: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibUserManagement) CreateUser(ctx context.Context) error {
                                          ^
server/grpcsvr/oob/bmc/users_bmclib.go:56:2: variable 'err' is only used in the if-statement (server/grpcsvr/oob/bmc/users_bmclib.go:57:2); consider using short syntax (ifshort)
	err := b.conn.User(users)
	^
server/grpcsvr/oob/bmc/users_bmclib.go:66:43: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibUserManagement) UpdateUser(ctx context.Context) error {
                                          ^
server/grpcsvr/oob/bmc/users_bmclib.go:75:2: variable 'err' is only used in the if-statement (server/grpcsvr/oob/bmc/users_bmclib.go:76:2); consider using short syntax (ifshort)
	err := b.conn.User(users)
	^
server/grpcsvr/oob/bmc/users_bmclib.go:85:43: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibUserManagement) DeleteUser(ctx context.Context) error {
                                          ^
server/grpcsvr/oob/common.go:13:33: Comment should end in a period (godot)
// Connection methods open/close
                                ^
server/grpcsvr/oob/common.go:19:33: Comment should end in a period (godot)
// Accessory for all BMC actions
                                ^
server/grpcsvr/oob/common.go:25:39: Comment should end in a period (godot)
// Connect to a BMC interface function
                                      ^
server/grpcsvr/oob/common.go:30:34: Comment should end in a period (godot)
// Close a BMC interface function
                                 ^
server/grpcsvr/oob/common.go:74:61: Comment should end in a period (godot)
// ParseAuth will return host, user, passwd from auth struct
                                                            ^
server/grpcsvr/oob/common.go:92:58: Comment should end in a period (godot)
// SendStatusMessage will send a message to a string chan
                                                         ^
server/grpcsvr/oob/common_test.go:112:31: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (t *testConnect) Connect(ctx context.Context) error {
                              ^
server/grpcsvr/oob/common_test.go:119:29: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (t *testConnect) Close(ctx context.Context) {}
                            ^
server/grpcsvr/oob/common_test.go:151: unnecessary trailing newline (whitespace)

			} else {
server/grpcsvr/oob/common_test.go:159: unnecessary trailing newline (whitespace)

		})
server/grpcsvr/oob/machine/machine.go:16:77: Comment should end in a period (godot)
// Action for making power actions on BMCs, implements oob.Machine interface
                                                                            ^
server/grpcsvr/oob/machine/machine.go:23:31: Comment should end in a period (godot)
// Option to add to an Actions
                              ^
server/grpcsvr/oob/machine/machine.go:26:46: Comment should end in a period (godot)
// WithLogger adds a logr to an Action struct
                                             ^
server/grpcsvr/oob/machine/machine.go:34:68: Comment should end in a period (godot)
// WithStatusMessage adds a status message chan to an Action struct
                                                                   ^
server/grpcsvr/oob/machine/machine.go:42:60: Comment should end in a period (godot)
// WithDeviceRequest adds DeviceRequest to an Action struct
                                                           ^
server/grpcsvr/oob/machine/machine.go:50:58: Comment should end in a period (godot)
// WithPowerRequest adds PowerRequest to an Action struct
                                                         ^
server/grpcsvr/oob/machine/machine.go:58:55: Comment should end in a period (godot)
// NewPowerSetter returns an oob.PowerSetter interface
                                                      ^
server/grpcsvr/oob/machine/machine.go:70:65: Comment should end in a period (godot)
// NewBootDeviceSetter returns an oob.BootDeviceSetter interface
                                                                ^
server/grpcsvr/oob/machine/machine.go:82:44: Comment should end in a period (godot)
// BootDeviceSet functionality for machines
                                           ^
server/grpcsvr/oob/machine/machine.go:99:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//client.Registry.Drivers = client.Registry.FilterForCompatible(ctx)
	^
server/grpcsvr/oob/machine/machine.go:152:39: Comment should end in a period (godot)
// PowerSet functionality for machines
                                      ^
server/grpcsvr/oob/machine/machine.go:188:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/machine/machine.go:190:4: defer: prefer not to defer inside loops (revive)
			defer r.Close(ctx)
			^
server/grpcsvr/oob/machine/machine.go:192:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch r := conn.(type) {
		^
server/grpcsvr/oob/machine/machine_power_bmclib.go:41:27: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) Close(ctx context.Context) {
                          ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:77:24: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) on(ctx context.Context) (result string, err error) {
                       ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:94:25: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) off(ctx context.Context) (result string, err error) {
                        ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:111:28: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) status(ctx context.Context) (result string, err error) {
                           ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:122:27: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) reset(ctx context.Context) (result string, err error) {
                          ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:136:9: string `reset` has 5 occurrences, make it a constant (goconst)
	return "reset", nil
	       ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:139:29: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) hardoff(ctx context.Context) (result string, err error) {
                            ^
server/grpcsvr/oob/machine/machine_power_bmclib.go:156:27: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *bmclibBMC) cycle(ctx context.Context) (result string, err error) {
                          ^
server/grpcsvr/oob/machine/machine_power_bmclib2.go:23:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//b.conn.Registry.Drivers = b.conn.Registry.FilterForCompatible(ctx)
	^
server/grpcsvr/oob/machine/machine_power_redfish.go:25:30: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *redfishBMC) Connect(ctx context.Context) error {
                             ^
server/grpcsvr/oob/machine/machine_power_redfish.go:44:28: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *redfishBMC) Close(ctx context.Context) {
                           ^
server/grpcsvr/oob/machine/machine_power_redfish.go:80:25: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *redfishBMC) on(ctx context.Context) (result string, err error) {
                        ^
server/grpcsvr/oob/machine/machine_power_redfish.go:103:26: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *redfishBMC) off(ctx context.Context) (result string, err error) {
                         ^
server/grpcsvr/oob/machine/machine_power_redfish.go:126:29: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *redfishBMC) status(ctx context.Context) (result string, err error) {
                            ^
server/grpcsvr/oob/machine/machine_power_redfish.go:169:30: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *redfishBMC) hardoff(ctx context.Context) (result string, err error) {
                             ^
server/grpcsvr/persistence/repo.go:13:62: Comment should end in a period (godot)
// GoKV store, methods implement repository.Actions interface
                                                             ^
server/grpcsvr/persistence/repo.go:19:19: Comment should end in a period (godot)
// Create a record
                  ^
server/grpcsvr/persistence/repo.go:24:16: Comment should end in a period (godot)
// Get a record
               ^
server/grpcsvr/persistence/repo.go:32:9: errorf: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...) (revive)
		err = errors.New(fmt.Sprintf("record id not found: %v", id))
		      ^
server/grpcsvr/persistence/repo.go:37:19: Comment should end in a period (godot)
// Update a record
                  ^
server/grpcsvr/persistence/repo.go:45:10: errorf: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...) (revive)
		return errors.New(fmt.Sprintf("record id not found: %v", id))
		       ^
server/grpcsvr/persistence/repo.go:50:19: Comment should end in a period (godot)
// Delete a record
                  ^
server/grpcsvr/persistence/repo_test.go:81: unnecessary trailing newline (whitespace)

}
server/grpcsvr/rpc/bmc.go:15:36: Comment should end in a period (godot)
// BmcService for doing BMC actions
                                   ^
server/grpcsvr/rpc/bmc.go:27:45: Comment should end in a period (godot)
// NetworkSource sets the BMC network source
                                            ^
server/grpcsvr/rpc/bmc.go:28:36: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (b *BmcService) NetworkSource(ctx context.Context, in *v1.NetworkSourceRequest) (*v1.NetworkSourceResponse, error) {
                                   ^
server/grpcsvr/rpc/bmc.go:32:32: Comment should end in a period (godot)
// Reset calls a reset on a BMC
                               ^
server/grpcsvr/rpc/bmc.go:46:3: import-shadowing: The name 'task' shadows an import name (revive)
		task, err := bmc.NewBMCResetter(
		^
server/grpcsvr/rpc/bmc.go:66:53: Comment should end in a period (godot)
// CreateUser sets the next boot device of a machine
                                                    ^
server/grpcsvr/rpc/bmc.go:82:3: import-shadowing: The name 'task' shadows an import name (revive)
		task, err := bmc.NewBMC(
		^
server/grpcsvr/rpc/bmc.go:99:51: Comment should end in a period (godot)
// UpdateUser updates a users credentials on a BMC
                                                  ^
server/grpcsvr/rpc/bmc.go:115:3: import-shadowing: The name 'task' shadows an import name (revive)
		task, err := bmc.NewBMC(
		^
server/grpcsvr/rpc/bmc.go:132:38: Comment should end in a period (godot)
// DeleteUser deletes a user on a BMC
                                     ^
server/grpcsvr/rpc/bmc.go:146:3: import-shadowing: The name 'task' shadows an import name (revive)
		task, err := bmc.NewBMC(
		^
server/grpcsvr/rpc/bmc_test.go:67:4: deep-exit: calls to os.Exit only in main() or init() functions (revive)
			os.Exit(3)
			^
server/grpcsvr/rpc/bmc_test.go:72: unnecessary trailing newline (whitespace)

}
server/grpcsvr/rpc/bmc_test.go:115:15: `reponse` is a misspelling of `response` (misspell)
				t.Fatalf("reponse should be nil, got: %v", response)
				          ^
server/grpcsvr/rpc/bmc_test.go:175:11: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
			} else {
			       ^
server/grpcsvr/rpc/bmc_test.go:239:11: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
			} else {
			       ^
server/grpcsvr/rpc/bmc_test.go:303:11: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
			} else {
			       ^
server/grpcsvr/rpc/bmc_test.go:363:11: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
			} else {
			       ^
server/grpcsvr/rpc/machine.go:14:53: Comment should end in a period (godot)
// MachineService for doing power and device actions
                                                    ^
server/grpcsvr/rpc/machine.go:26:53: Comment should end in a period (godot)
// BootDevice sets the next boot device of a machine
                                                    ^
server/grpcsvr/rpc/machine.go:60:43: Comment should end in a period (godot)
// Power does a power action against a BMC
                                          ^
server/grpcsvr/rpc/machine_test.go:92: unnecessary trailing newline (whitespace)

			} else {
server/grpcsvr/rpc/machine_test.go:198: unnecessary trailing newline (whitespace)

			} else {
server/grpcsvr/rpc/machine_test.go:202: unnecessary trailing newline (whitespace)

		})
server/grpcsvr/rpc/task.go:13:43: Comment should end in a period (godot)
// TaskService for retrieving task details
                                          ^
server/grpcsvr/rpc/task.go:20:32: Comment should end in a period (godot)
// Status returns a task record
                               ^
server/grpcsvr/rpc/task_test.go:43:43: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
		return "doing cool stuff", defaultError // nolint
		                                        ^
server/grpcsvr/rpc/task_test.go:61: unnecessary trailing newline (whitespace)

}
server/grpcsvr/server.go:25:18: Comment should end in a period (godot)
// Server options
                 ^
server/grpcsvr/server.go:31:44: Comment should end in a period (godot)
// ServerOption for setting optional values
                                           ^
server/grpcsvr/server.go:34:38: Comment should end in a period (godot)
// WithPersistence sets the log level
                                     ^
server/grpcsvr/server.go:39:49: Comment should end in a period (godot)
// WithBmcTimeout sets the timeout for BMC calls
                                                ^
server/grpcsvr/server.go:44:56: Comment should end in a period (godot)
// RunServer registers all services and runs the server
                                                       ^
server/grpcsvr/server.go:108:4: deep-exit: calls to os.Exit only in main() or init() functions (revive)
			os.Exit(1)
			^
server/grpcsvr/server_test.go:123: unnecessary trailing newline (whitespace)

}
server/grpcsvr/taskrunner/taskrunner.go:19:31: Comment should end in a period (godot)
// Runner for executing a task
                              ^
server/grpcsvr/taskrunner/taskrunner.go:29:65: Comment should end in a period (godot)
// ActiveWorkers returns a count of currently active worker jobs
                                                                ^
server/grpcsvr/taskrunner/taskrunner.go:36:55: Comment should end in a period (godot)
// TotalWorkers returns a count total workers executed
                                                      ^
server/grpcsvr/taskrunner/taskrunner.go:43:49: Comment should end in a period (godot)
// Execute a task, update repository with status
                                                ^
server/grpcsvr/taskrunner/taskrunner.go:49:37: Comment should end in a period (godot)
// TODO handle retrys, use a timeout
                                    ^
server/grpcsvr/taskrunner/taskrunner.go:97:30: appendAssign: append result not assigned to the same slice (gocritic)
				sessionRecord.Messages = append(currStatus.Messages, msg)
				                         ^
server/grpcsvr/taskrunner/taskrunner.go:140:46: Comment should end in a period (godot)
// Status returns the status record of a task
                                             ^
server/grpcsvr/taskrunner/taskrunner.go:141:25: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *Runner) Status(ctx context.Context, taskID string) (record repository.Record, err error) {
                        ^
server/grpcsvr/taskrunner/taskrunner_test.go:41:44: directive `//nolint` should mention specific linter such as `//nolint:my-linter` (nolintlint)
		return "didnt do anything", defaultError //nolint
		                                         ^
server/grpcsvr/taskrunner/taskrunner_test.go:54:5: bool-literal-in-expr: omit Boolean literal in expression (revive)
	if record.Complete != true {
	   ^
server/httpsvr/api/api.go:40:25: Comment should end in a period (godot)
// Serve serves http api
                        ^
server/httpsvr/api/api.go:102:2: import-shadowing: The name 'log' shadows an import name (revive)
	log := true
	^
server/httpsvr/api/bmc.go:29:16: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
		c.Error(err) // nolint
		             ^
server/httpsvr/api/boot.go:27:16: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
		c.Error(err) // nolint
		             ^
server/httpsvr/api/errors.go:15:49: Comment should end in a period (godot)
	// ErrBadAccessID indicate an invalid access id
	                                               ^
server/httpsvr/api/errors.go:17:66: Comment should end in a period (godot)
	// ErrBadAuthorization indicates an invalid authorization header
	                                                                ^
server/httpsvr/api/errors.go:19:48: Comment should end in a period (godot)
	// ErrBadDate indicates an invalid date header
	                                              ^
server/httpsvr/api/errors.go:21:59: Comment should end in a period (godot)
	// ErrBadSignature indicates an invalid request signature
	                                                         ^
server/httpsvr/api/errors.go:23:47: Comment should end in a period (godot)
	// ErrNotSigned indicates an unsigned request
	                                             ^
server/httpsvr/api/errors.go:25:45: Comment should end in a period (godot)
	// ErrTooOld indicates an expired signature
	                                           ^
server/httpsvr/api/errors.go:56:42: `internalServerError` - `errs` always receives `nil` (unparam)
func internalServerError(c *gin.Context, errs ...error) {
                                         ^
server/httpsvr/api/lan.go:29:16: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
		c.Error(err) // nolint
		             ^
server/httpsvr/api/power.go:79:16: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
		c.Error(err) // nolint
		             ^
server/httpsvr/api/power.go:82:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
	} else {
		renderPowerStatus(c, status)
	}
server/httpsvr/api/redfish/proxy.go:27:2: type assertion must be checked (forcetypeassert)
	ctx := req.Context().Value(redfishCTX).(*gin.Context)
	^
server/httpsvr/api/redfish/proxy.go:45:62: Comment should end in a period (godot)
// Proxies /device/{ip}/redfish/{path} to {ip}/redfish/{path}
                                                             ^
server/httpsvr/drivers/ipmitool/bmc.go:30:31: Comment should end in a period (godot)
// BMC runs actions on the BMC
                              ^
server/httpsvr/drivers/ipmitool/boot.go:33:36: Comment should end in a period (godot)
// SetBootOptions sets boot options
                                   ^
server/httpsvr/drivers/ipmitool/errors.go:13:85: Comment should end in a period (godot)
	// ErrConnect mimics the ipmitool response when a connection can not be established
	                                                                                   ^
server/httpsvr/drivers/ipmitool/errors.go:15:88: Comment should end in a period (godot)
	// ErrStatus mimics the ipmitool response when it is unable to get chasis power status
	                                                                                      ^
server/httpsvr/drivers/ipmitool/errors.go:17:98: Comment should end in a period (godot)
	// ErrChannelCipherSuites mimics the ipmitool response when it there is a cypher suites mismatch
	                                                                                                ^
server/httpsvr/drivers/ipmitool/lan.go:17:44: Comment should end in a period (godot)
// SetIPSource sets ip configuration method
                                           ^
server/httpsvr/drivers/ipmitool/logging.go:7:47: Comment should end in a period (godot)
	// VerboseDebug enables verbose/debug logging
	                                             ^
server/httpsvr/drivers/ipmitool/options.go:12:5: var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
var DEFAULT_CIPHER = os.Getenv("IPMITOOL_DEFAULT_CIPHER")
    ^
server/httpsvr/drivers/ipmitool/options.go:14:35: Comment should end in a period (godot)
// ExecutablePath path to ipmitool
                                  ^
server/httpsvr/drivers/ipmitool/options.go:17:44: Comment should end in a period (godot)
// Options are the options ipmitool accepts
                                           ^
server/httpsvr/drivers/ipmitool/options.go:29:69: Comment should end in a period (godot)
// NewOptions returns an Options struct with the values provided set
                                                                    ^
server/httpsvr/drivers/ipmitool/power.go:32:30: Comment should end in a period (godot)
// Power sets the power state
                             ^
server/httpsvr/drivers/ipmitool/power.go:46:39: Comment should end in a period (godot)
// PowerStatus returns the power state
                                      ^
server/httpsvr/drivers/ipmitool/shell.go:26:41: Comment should end in a period (godot)
// Shell represents an open remote shell
                                        ^
server/httpsvr/drivers/ipmitool/shell.go:71:31: Comment should end in a period (godot)
// Shell starts a remote shell
                              ^
server/httpsvr/drivers/ipmitool/shell.go:72:21: ST1016: methods on the same type should have the same receiver name (seen 1x "o", 1x "opts") (stylecheck)
func (opts Options) Shell(ctx context.Context) (*Shell, error) {
                    ^
server/httpsvr/drivers/ipmitool/shell.go:103:36: `guranteed` is a misspelling of `guaranteed` (misspell)
	// TODO(mmlb): finalizers are not guranteed to be invoked, figure out a different way to ensure no leaks
	                                  ^
server/httpsvr/drivers/ipmitool/shell.go:107:32: Comment should end in a period (godot)
// Close stops the remote shell
                               ^
server/httpsvr/drivers/ipmitool/shell.go:112:46: Comment should end in a period (godot)
// Run executes a command on the remote shell
                                             ^
server/httpsvr/drivers/ipmitool/shell.go:130:48: Comment should end in a period (godot)
// LastStatus returns the previous power status
                                               ^
server/httpsvr/drivers/ipmitool/shell.go:228:6: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
		if err.Errors[0] == ErrChannelCipherSuites {
		   ^
server/httpsvr/drivers/racadm/bmc.go:30:31: Comment should end in a period (godot)
// BMC runs actions on the BMC
                              ^
server/httpsvr/drivers/racadm/boot.go:39:36: Comment should end in a period (godot)
// SetBootOptions sets boot options
                                   ^
server/httpsvr/drivers/racadm/boot.go:53:2: variable 'err' is only used in the if-statement (server/httpsvr/drivers/racadm/boot.go:54:2); consider using short syntax (ifshort)
	err := s.Run(cmd)
	^
server/httpsvr/drivers/racadm/boot.go:61:51: Comment should end in a period (godot)
// BootOptions returns the configured boot options
                                                  ^
server/httpsvr/drivers/racadm/lan.go:20:44: Comment should end in a period (godot)
// SetIPSource sets ip configuration method
                                           ^
server/httpsvr/drivers/racadm/lan.go:24:10: errorf: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...) (revive)
		return errors.New(fmt.Sprintf("ip source %q not supported by racadm driver", source))
		       ^
server/httpsvr/drivers/racadm/logging.go:7:47: Comment should end in a period (godot)
	// VerboseDebug enables verbose/debug logging
	                                             ^
server/httpsvr/drivers/racadm/options.go:6:42: Comment should end in a period (godot)
// Options are the options racadm accepts
                                         ^
server/httpsvr/drivers/racadm/options.go:13:69: Comment should end in a period (godot)
// NewOptions returns an Options struct with the values provided set
                                                                    ^
server/httpsvr/drivers/racadm/power.go:35:30: Comment should end in a period (godot)
// Power sets the power state
                             ^
server/httpsvr/drivers/racadm/power.go:50:39: Comment should end in a period (godot)
// PowerStatus returns the power state
                                      ^
server/httpsvr/drivers/racadm/power.go:70:48: Comment should end in a period (godot)
// LastStatus returns the previous power status
                                               ^
server/httpsvr/drivers/racadm/shell.go:17:41: Comment should end in a period (godot)
// Shell represents an open remote shell
                                        ^
server/httpsvr/drivers/racadm/shell.go:46:45: unused-parameter: parameter 'user' seems to be unused, consider removing or renaming it as _ (revive)
func (opts Options) AuthKeyboardInteractive(user, instruction string, questions []string, echos []bool) ([]string, error) {
                                            ^
server/httpsvr/drivers/racadm/shell.go:55:31: Comment should end in a period (godot)
// Shell starts a remote shell
                              ^
server/httpsvr/drivers/racadm/shell.go:82:32: Comment should end in a period (godot)
// Close stops the remote shell
                               ^
server/httpsvr/drivers/racadm/shell.go:87:46: Comment should end in a period (godot)
// Run executes a command on the remote shell
                                             ^
server/httpsvr/drivers/racadm/shell.go:111:5: argOrder: probably meant `strings.HasPrefix(out, "ERROR: ")` (gocritic)
	if strings.HasPrefix("ERROR: ", out) {
	   ^
server/httpsvr/drivers/racadm/shell.go:118:72: Comment should end in a period (godot)
// Output executes a command on the remote shell and returns any output
                                                                       ^
server/httpsvr/evlog/evlog.go:13:23: Comment should end in a period (godot)
// Log embeds a Logger
                      ^
server/httpsvr/evlog/evlog.go:18:30: Comment should end in a period (godot)
// New instantiates a new Log
                             ^
server/httpsvr/evlog/evlog.go:23:74: Comment should end in a period (godot)
// TxFromContext returns a new Tx, using the id from the provided context
                                                                         ^
server/httpsvr/evlog/trace.go:11:48: Comment should end in a period (godot)
// Trace is used for detailed tracing of events
                                               ^
server/httpsvr/evlog/trace.go:22:55: Comment should end in a period (godot)
// Stop records the time, along with any non-nil error
                                                      ^
server/httpsvr/evlog/tx.go:11:34: Comment should end in a period (godot)
// Tx is used for loggin an event
                                 ^
server/httpsvr/evlog/tx.go:20:31: assignOp: replace `i = i + 2` with `i += 2` (gocritic)
	for i := 0; i < len(fields); i = i + 2 {
	                             ^
server/httpsvr/evlog/tx.go:27:16: Comment should end in a period (godot)
// With returns
               ^
server/httpsvr/evlog/tx.go:34:54: Comment should end in a period (godot)
// Panic is a helper function to log a CRITICAL event
                                                     ^
server/httpsvr/evlog/tx.go:39:46: Comment should end in a period (godot)
// Error is a helper function to log an error
                                             ^
server/httpsvr/evlog/tx.go:44:49: Comment should end in a period (godot)
// Warning is a helper function to log a warning
                                                ^
server/httpsvr/evlog/tx.go:49:47: Comment should end in a period (godot)
// Notice is a helper function to log a notice
                                              ^
server/httpsvr/evlog/tx.go:54:52: Comment should end in a period (godot)
// Info is a helper function to log an info message
                                                   ^
server/httpsvr/evlog/tx.go:59:53: Comment should end in a period (godot)
// Debug is a helper function to log a debug message
                                                    ^
server/httpsvr/evlog/tx.go:64:53: Comment should end in a period (godot)
// Trace is a helper function to log a trace message
                                                    ^
server/httpsvr/interfaces/bmc/bmc.go:18:56: Comment should end in a period (godot)
// Action is used to denote the available power actions
                                                       ^
server/httpsvr/interfaces/bmc/bmc.go:22:22: Comment should end in a period (godot)
	// NoAction is a NOP
	                    ^
server/httpsvr/interfaces/bmc/bmc.go:24:32: Comment should end in a period (godot)
	// ColdReset does a cold reset
	                              ^
server/httpsvr/interfaces/bmc/bmc.go:26:32: Comment should end in a period (godot)
	// WarmReset does a warm reset
	                              ^
server/httpsvr/interfaces/bmc/bmc.go:34:54: Comment should end in a period (godot)
// ActionsBySlug is a reverse mapping of Action types
                                                     ^
server/httpsvr/interfaces/bmc/bmc.go:40:68: Comment should end in a period (godot)
// UnmarshalText unmarshals an Action from a textual representation
                                                                   ^
server/httpsvr/interfaces/bmc/bmc.go:49:43: Comment should end in a period (godot)
// Driver is the interface to control BMCs
                                          ^
server/httpsvr/interfaces/bmc/bmc.go:57:53: Comment should end in a period (godot)
// DriverFactory is used to instantiate a new Driver
                                                    ^
server/httpsvr/interfaces/bmc/bmc.go:60:71: Comment should end in a period (godot)
// DriverOptions contain the basic options needed to connect to device
                                                                      ^
server/httpsvr/interfaces/bmc/bmc.go:69:82: Comment should end in a period (godot)
// NewDriver instantiates a new driver by calling the registered factory function
                                                                                 ^
server/httpsvr/interfaces/bmc/bmc.go:78:124: Comment should end in a period (godot)
// RegisterDriver is called by implementations in order to register their factory function for each device they can control
                                                                                                                           ^
server/httpsvr/interfaces/bmc/http.go:14:79: Comment should end in a period (godot)
// NewDriverFromGinContext creates a new Driver using info in the http request
                                                                              ^
server/httpsvr/interfaces/bmc/lan.go:8:51: Comment should end in a period (godot)
// IPSource denotes the types of ip configurations
                                                  ^
server/httpsvr/interfaces/bmc/lan.go:12:49: Comment should end in a period (godot)
	// IPFromDHCP denotes ip via dhcp configuration
	                                               ^
server/httpsvr/interfaces/bmc/lan.go:14:49: Comment should end in a period (godot)
	// StaticIP denotes ip via static configuration
	                                               ^
server/httpsvr/interfaces/bmc/lan.go:18:62: Comment should end in a period (godot)
// IPSourceBySlug is a reverse mapping of strings to IPSource
                                                             ^
server/httpsvr/interfaces/bmc/lan.go:24:70: Comment should end in a period (godot)
// UnmarshalText unmarshals an IPSource from a textual representation
                                                                     ^
server/httpsvr/interfaces/boot/boot.go:18:36: Comment should end in a period (godot)
// Device describe bootable devices
                                   ^
server/httpsvr/interfaces/boot/boot.go:22:45: Comment should end in a period (godot)
	// DefaultDevice is the default boot device
	                                           ^
server/httpsvr/interfaces/boot/boot.go:24:57: Comment should end in a period (godot)
	// ForcePXE is used to configure pxe as the boot device
	                                                       ^
server/httpsvr/interfaces/boot/boot.go:26:59: Comment should end in a period (godot)
	// ForceDisk is used to configure disk as the boot device
	                                                         ^
server/httpsvr/interfaces/boot/boot.go:28:59: Comment should end in a period (godot)
	// ForceBIOS is used to configure bios as the boot device
	                                                         ^
server/httpsvr/interfaces/boot/boot.go:36:43: Comment should end in a period (godot)
// Driver is the interface to control boot
                                          ^
server/httpsvr/interfaces/boot/boot.go:43:53: Comment should end in a period (godot)
// DriverFactory is used to instantiate a new Driver
                                                    ^
server/httpsvr/interfaces/boot/boot.go:46:71: Comment should end in a period (godot)
// DriverOptions contain the basic options needed to connect to device
                                                                      ^
server/httpsvr/interfaces/boot/boot.go:55:52: Comment should end in a period (godot)
// Options contain values relevant for boot actions
                                                   ^
server/httpsvr/interfaces/boot/boot.go:67:82: Comment should end in a period (godot)
// NewDriver instantiates a new driver by calling the registered factory function
                                                                                 ^
server/httpsvr/interfaces/boot/boot.go:76:124: Comment should end in a period (godot)
// RegisterDriver is called by implementations in order to register their factory function for each device they can control
                                                                                                                           ^
server/httpsvr/interfaces/boot/http.go:14:79: Comment should end in a period (godot)
// NewDriverFromGinContext creates a new Driver using info in the http request
                                                                              ^
server/httpsvr/interfaces/power/http.go:14:79: Comment should end in a period (godot)
// NewDriverFromGinContext creates a new Driver using info in the http request
                                                                              ^
server/httpsvr/interfaces/power/operations.go:14:65: Comment should end in a period (godot)
	// PollingInterval specifies how often to poll for power action
	                                                               ^
server/httpsvr/interfaces/power/operations.go:18:54: Comment should end in a period (godot)
// Operation specifies which operations are available
                                                     ^
server/httpsvr/interfaces/power/operations.go:21:59: Comment should end in a period (godot)
// OperationBySlug lists the names of available operations
                                                          ^
server/httpsvr/interfaces/power/operations.go:34:71: Comment should end in a period (godot)
// UnmarshalText unmarshals an Operation from a textual representation
                                                                      ^
server/httpsvr/interfaces/power/operations.go:83:50: unused-parameter: parameter 'opts' seems to be unused, consider removing or renaming it as _ (revive)
func doReset(ctx context.Context, driver Driver, opts Options) (err error) {
                                                 ^
server/httpsvr/interfaces/power/operations.go:98:42: comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
	if err := doSoftOff(ctx, driver, opts); err != context.DeadlineExceeded {
	                                        ^
server/httpsvr/interfaces/power/operations.go:161:2: missing cases in switch of type Status: AnyStatus (exhaustive)
	switch target {
	^
server/httpsvr/interfaces/power/operations.go:178:2: missing cases in switch of type Status: Off, On (exhaustive)
	switch target {
	^
server/httpsvr/interfaces/power/power.go:21:44: Comment should end in a period (godot)
// Action is the type for available actions
                                           ^
server/httpsvr/interfaces/power/power.go:30:22: Comment should end in a period (godot)
	// NoAction is a Nop
	                    ^
server/httpsvr/interfaces/power/power.go:32:36: Comment should end in a period (godot)
	// TurnOn will power up the device
	                                  ^
server/httpsvr/interfaces/power/power.go:34:71: Comment should end in a period (godot)
	// SoftOff will perform a soft-shutdown (usually through OS via ACPI)
	                                                                     ^
server/httpsvr/interfaces/power/power.go:36:63: Comment should end in a period (godot)
	// HardOff will power off the device without informing the OS
	                                                             ^
server/httpsvr/interfaces/power/power.go:38:61: Comment should end in a period (godot)
	// Reset will perform a hard reset without informing the OS
	                                                           ^
server/httpsvr/interfaces/power/power.go:42:44: Comment should end in a period (godot)
// Driver is the interface to control power
                                           ^
server/httpsvr/interfaces/power/power.go:52:53: Comment should end in a period (godot)
// DriverFactory is used to instantiate a new Driver
                                                    ^
server/httpsvr/interfaces/power/power.go:55:71: Comment should end in a period (godot)
// DriverOptions contain the basic options needed to connect to device
                                                                      ^
server/httpsvr/interfaces/power/power.go:64:58: Comment should end in a period (godot)
// Options contain time values relevant for power actions
                                                         ^
server/httpsvr/interfaces/power/power.go:73:58: Comment should end in a period (godot)
// DefaultOptions are the default times for power actions
                                                         ^
server/httpsvr/interfaces/power/power.go:82:49: Comment should end in a period (godot)
// Status is the type for reporting power status
                                                ^
server/httpsvr/interfaces/power/power.go:86:47: Comment should end in a period (godot)
	// AnyStatus is a fallback for unknown status
	                                             ^
server/httpsvr/interfaces/power/power.go:88:51: Comment should end in a period (godot)
	// Off is returned when the device is powered off
	                                                 ^
server/httpsvr/interfaces/power/power.go:90:49: Comment should end in a period (godot)
	// On is returned when the device is powered on
	                                               ^
server/httpsvr/interfaces/power/power.go:94:82: Comment should end in a period (godot)
// NewDriver instantiates a new driver by calling the registered factory function
                                                                                 ^
server/httpsvr/interfaces/power/power.go:103:124: Comment should end in a period (godot)
// RegisterDriver is called by implementations in order to register their factory function for each device they can control
                                                                                                                           ^
server/httpsvr/interfaces/power/task.go:16:48: Comment should end in a period (godot)
// TaskTimeout is the default timeout for tasks
                                               ^
server/httpsvr/interfaces/power/task.go:24:50: Comment should end in a period (godot)
// FindTask fetches the Taskf for the provided id
                                                 ^
server/httpsvr/interfaces/power/task.go:35:57: Comment should end in a period (godot)
// DeleteTask deletes the Task with the corresponding id
                                                        ^
server/httpsvr/interfaces/power/task.go:46:38: Comment should end in a period (godot)
// CleanupTasks deletes expired tasks
                                     ^
server/httpsvr/interfaces/power/task.go:73:31: Comment should end in a period (godot)
// StartTask starts a new task
                              ^
server/httpsvr/interfaces/power/task.go:84:26: Comment should end in a period (godot)
// Task represents a task
                         ^
server/httpsvr/interfaces/power/task.go:114:81: Comment should end in a period (godot)
// Done returns a channel that will remain blocked while the task is in progress
                                                                                ^
server/httpsvr/interfaces/power/task.go:119:59: Comment should end in a period (godot)
// Err returns the first non-nil error encountered by Task
                                                          ^
server/httpsvr/interfaces/power/task.go:124:26: Comment should end in a period (godot)
// ID returns the task id
                         ^
server/httpsvr/interfaces/power/task.go:143:14: defer: recover must be called inside a deferred function (revive)
	if iface := recover(); iface != nil {
	            ^
server/httpsvr/log/log.go:19:48: Comment should end in a period (godot)
// Logger is a wrapper around zap.SugaredLogger
                                               ^
server/httpsvr/reqid/reqid.go:31:54: Comment should end in a period (godot)
// WithID returns a new Context that carries value id
                                                     ^
server/httpsvr/reqid/reqid.go:61:24: Comment should end in a period (godot)
// New creates a new id
                       ^
server/httpsvr/server.go:41:42: Comment should end in a period (godot)
// RunHTTPServer runs PBnJ v1 HTTP server
                                         ^
server/httpsvr/server.go:49:15: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
	defer sync() // nolint
	             ^
server/httpsvr/util/util.go:10:81: Comment should end in a period (godot)
// FindDriver finds the driver type given a manufacturer, defaulting to ipmitool
                                                                                ^
test/main.go:50:32: Comment should end in a period (godot)
// Returns an int >= min, < max
                               ^
test/runner/common.go:11:33: Comment should end in a period (godot)
// ConfigFile is the config file
                                ^
test/runner/common.go:17:36: Comment should end in a period (godot)
// Server is the connection details
                                   ^
test/runner/common.go:23:25: Comment should end in a period (godot)
// Data of BMC resources
                        ^
test/runner/common.go:28:31: Comment should end in a period (godot)
// UseCases classes with names
                              ^
test/runner/common.go:34:36: Comment should end in a period (godot)
// Resource details of a single BMC
                                   ^
test/runner/common.go:43:33: Comment should end in a period (godot)
// Config for the resources file
                                ^
test/runner/common.go:45:2: variable 'err' is only used in the if-statement (test/runner/common.go:46:2); consider using short syntax (ifshort)
	err := c.parseConfig(name)
	^
test/runner/common.go:48:3: deep-exit: calls to os.Exit only in main() or init() functions (revive)
		os.Exit(1)
		^
test/runner/common.go:52:44: Comment should end in a period (godot)
// parseConfig reads and validates a config
                                           ^
test/runner/runner.go:38:33: Comment should end in a period (godot)
// RunTests actions against BMCs
                                ^
test/runner/runner.go:136: unnecessary trailing newline (whitespace)

		}
test/runner/runner.go:224: 224-266 lines are duplicate of `test/runner/runner.go:268-310` (dupl)
func runBMCCreateUserClient(in testResource, action *v1.CreateUserRequest, s Server) (*v1.StatusResponse, error) {
	var opts []grpc.DialOption
	ctx := context.Background()
	ctx, cancel := context.WithCancel(ctx)
	defer cancel()

	opts = append(opts, grpc.WithInsecure())
	conn, err := grpc.Dial(s.URL+":"+s.Port, opts...)
	if err != nil {
		return nil, err
	}
	defer conn.Close()
	client := v1.NewBMCClient(conn)
	taskClient := v1.NewTaskClient(conn)

	inRequest := &v1.CreateUserRequest{
		Authn: &v1.Authn{
			Authn: &v1.Authn_DirectAuthn{
				DirectAuthn: &v1.DirectAuthn{
					Host: &v1.Host{
						Host: in.Host,
					},
					Username: in.Username,
					Password: in.Password,
				},
			},
		},
		Vendor: &v1.Vendor{
			Name: in.Vendor,
		},
		UserCreds: &v1.UserCreds{
			Username: action.UserCreds.Username,
			Password: action.UserCreds.Password,
			UserRole: action.UserCreds.UserRole,
		},
	}
	resp, err := v1Client.BMCCreateUser(ctx, client, taskClient, inRequest)
	if err != nil {
		return nil, err
	}

	return resp, nil
}
test/runner/runner.go:268:116: directive `// nolint` should mention specific linter such as `// nolint:my-linter` (nolintlint)
func runBMCUpdateUserClient(in testResource, action *v1.UpdateUserRequest, s Server) (*v1.StatusResponse, error) { // nolint
                                                                                                                   ^
test/runner/tests.go:14:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//powerRequestRESET   = v1.PowerAction_POWER_ACTION_RESET
	^
test/runner/tests.go:16:56: Comment should end in a period (godot)
	//deviceRequestNONE   = v1.BootDevice_BOOT_DEVICE_NONE
	                                                      ^
test/runner/tests.go:18:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//deviceRequestDISK   = v1.BootDevice_BOOT_DEVICE_DISK
	^
test/runner/tests.go:19:57: Comment should end in a period (godot)
	//deviceRequestCDROM  = v1.BootDevice_BOOT_DEVICE_CDROM
	                                                       ^
test/runner/tests.go:24:3: commentFormatting: put a space between `//` and comment text (gocritic)
		//"notIdentifiableTests": notIdentifiableTests,
		^
test/runner/tests.go:130:3: commentFormatting: put a space between `//` and comment text (gocritic)
		//"power hardoff": {Action: &PowerRequest_HARDOFF, Want: notImplementedWant("HARD OFF")},
		^
```

### Shell

```
In examples/clients/ruby/demo.sh line 7:
    for proto in $(ls ../../../api/v1/*.proto); do
                 ^---------------------------^ SC2045: Iterating over ls output is fragile. Use globs.


In examples/clients/ruby/demo.sh line 8:
        grpc_tools_ruby_protoc -I ../../.. --ruby_out=./lib --grpc_out=./lib $proto 
                                                                             ^----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
        grpc_tools_ruby_protoc -I ../../.. --ruby_out=./lib --grpc_out=./lib "$proto" 


In examples/clients/ruby/demo.sh line 38:
ruby main.rb $1 $2 $3 | jq
             ^-- SC2086: Double quote to prevent globbing and word splitting.
                ^-- SC2086: Double quote to prevent globbing and word splitting.
                   ^-- SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
ruby main.rb "$1" "$2" "$3" | jq


In scripts/http/verify_power_status.sh line 10:
access_id=$ACCESS_ID
          ^--------^ SC2153: Possible misspelling: ACCESS_ID may not be assigned, but access_id is.


In scripts/http/verify_power_status.sh line 11:
access_secret=$ACCESS_SECRET
              ^------------^ SC2153: Possible misspelling: ACCESS_SECRET may not be assigned, but access_secret is.


In scripts/http/verify_power_status.sh line 19:
sig=$(echo -n "GET,$content_type,,$uri,$d" | openssl dgst -sha1 -binary -hmac $access_secret | base64)
                                                                              ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
sig=$(echo -n "GET,$content_type,,$uri,$d" | openssl dgst -sha1 -binary -hmac "$access_secret" | base64)


In scripts/http/verify_power_status.sh line 27:
	"$host$uri" | jq -r -S .state | grep -iE '^(on|off)$' && exit 0 || :
                                                              ^-- SC2015: Note that A && B || C is not if-then-else. C may run when A is true.
```