### PR TITLE
Add bmclib client metadata to to OTEL spans

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/jacobweinstock/bmclib v0.4.11-0.20211026200041-a5c2bc0d9629 h1:OEp2L1YB6VgeBu/8WA9feZfVV4G79rzXT/raPwl6oAk=
-github.com/jacobweinstock/bmclib v0.4.11-0.20211026200041-a5c2bc0d9629/go.mod h1:9YhAIIwp9tQtlo1LZtN5Qd89e+RfvgQ62ikbreEKOs0=
 github.com/jacobweinstock/registrar v0.4.2 h1:ifM6NNKpU3xrUIEZjwMLZZEeom5q7V8NfwDEEhdsAHo=
 github.com/jacobweinstock/registrar v0.4.2/go.mod h1:69P9dxcMVsAKUwiVRwkchq/BJyBXSFSMJcvl7PhsI2k=
 github.com/jacobweinstock/rollzap v0.1.3 h1:9nkpwYew+JiDoMWwVIEUpFyos6hdfY3gDmaj6d+Hq9M=

--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -145,6 +145,11 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 
 	m.SendStatusMessage("connecting to BMC")
 	err = client.Open(ctx)
+	meta := client.GetMetadata()
+	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
+		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
+		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return "", &repository.Error{
@@ -162,6 +167,11 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 
 	ok, err := client.SetBootDevice(ctx, dev, persistent, efiBoot)
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
+	meta = client.GetMetadata()
+	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
+		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
+		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
 	if err != nil {
 		log.Error(err, "failed to set boot device")
 	} else if !ok {
@@ -245,6 +255,12 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
 
 	err = client.Open(ctx)
+	meta := client.GetMetadata()
+	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
+		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
+		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
+
 	if err != nil {
 		span.SetStatus(codes.Error, "connecting to BMC failed: "+err.Error())
 		m.SendStatusMessage("connecting to BMC failed")
@@ -267,7 +283,13 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	// fetch the current power state that will be returned by "status"
 	// or used for control in cycle, and is always sent in traces
 	currentPowerState, err := client.GetPowerState(ctx)
+	meta = client.GetMetadata()
+	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
+		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
+		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
 	if err != nil {
+		span.SetStatus(codes.Error, "failed to get power state")
 		log.Error(err, "failed to get power state")
 		m.SendStatusMessage("error getting power state: " + err.Error())
 		return "", &repository.Error{
@@ -292,6 +314,11 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 		}
 		ok, err = client.SetPowerState(ctx, pwrAction)
 		result = fmt.Sprintf("%v complete", base)
+		meta = client.GetMetadata()
+		span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
+			attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
+			attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
+			attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
 	}
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	if err != nil {


### PR DESCRIPTION
## Description

This adds the metadata from bmclib into the OTEL spans so that we can understand if certain failures are related to a specific bmclib provider.
It also fixes one instance where a span wasn't correctly labeled as an error.

## How Has This Been Tested?
- go test ./...
- CI ?
- Manually running a local instance configured to emit traces

## How are existing users impacted? What migration steps/scripts do we need?
N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade