### PR TITLE
Add the error message to the client.PowerSet trace

### DIFF
--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -289,7 +289,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
 		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to get power state")
+		span.SetStatus(codes.Error, "failed to get power state: "+err.Error())
 		log.Error(err, "failed to get power state")
 		m.SendStatusMessage("error getting power state: " + err.Error())
 		return "", &repository.Error{
@@ -322,7 +322,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	}
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to set power state"+base)
+		span.SetStatus(codes.Error, "failed to set power state: "+base+": "+err.Error())
 		log.Error(err, "failed to set power state "+base)
 		m.SendStatusMessage("error with " + base + ": " + err.Error())
 	}


### PR DESCRIPTION
## Description

This puts the error message from e.g. ipmitool into the trace right when the command runs.
It also passes along RPC context into the Task so that we know which RPC triggered a Task.

## Why is this needed

This eases debugging of bmclib failures in the span where the command was run.

## How Has This Been Tested?
- I ran an updated container and confirmed that the improved error message showed up in Jaeger
- The parent-child relationship also now exists.

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade