### PR TITLE
Fix power on string in cycle check:

### DIFF
--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -309,7 +309,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 			// if powered on, do cycle
 			// if powered off, do power on
 			if strings.Contains(strings.ToLower(currentPowerState), "off") {
-				pwrAction = v1.PowerAction_POWER_ACTION_ON.String()
+				pwrAction = "on"
 			}
 		}
 		ok, err = client.SetPowerState(ctx, pwrAction)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This fixes power cycle requests. At line [307](https://github.com/tinkerbell/pbnj/blob/1ffd6a4ffbf4c8341e05cea09c4440537099e32a/grpc/oob/machine/machine.go#L307) If `action == v1.PowerAction_POWER_ACTION_CYCLE.String()` then we set the requested power state to be  the string `"POWER_ACTION_ON"`. This causes the `client.SetPowerState(ctx, pwrAction)` to fail as the string `"POWER_ACTION_ON"` is not recognized by bmclib. We need to pass `"on"` as is done in line [219](https://github.com/tinkerbell/pbnj/blob/1ffd6a4ffbf4c8341e05cea09c4440537099e32a/grpc/oob/machine/machine.go#L219).

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually against `vaporio/ipmi-simulator` container image.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
