### PR TITLE
Tune otel

### DIFF
--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -256,10 +256,8 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 
 	err = client.Open(ctx)
 	meta := client.GetMetadata()
-	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
-		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
-		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
-		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
+	span.SetAttributes(attribute.StringSlice("bmc.open.providersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmc.open.successfulOpenConns", meta.SuccessfulOpenConns))
 
 	if err != nil {
 		span.SetStatus(codes.Error, "connecting to BMC failed: "+err.Error())
@@ -284,10 +282,8 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	// or used for control in cycle, and is always sent in traces
 	currentPowerState, err := client.GetPowerState(ctx)
 	meta = client.GetMetadata()
-	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
-		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
-		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
-		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
+	span.SetAttributes(attribute.String("bmc.getPowerState.successfulProvider", meta.SuccessfulProvider),
+		attribute.StringSlice("bmc.getPowerState.providersAttempted", meta.ProvidersAttempted))
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get power state: "+err.Error())
 		log.Error(err, "failed to get power state")
@@ -315,10 +311,8 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 		ok, err = client.SetPowerState(ctx, pwrAction)
 		result = fmt.Sprintf("%v complete", base)
 		meta = client.GetMetadata()
-		span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
-			attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
-			attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
-			attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
+		span.SetAttributes(attribute.String("bmc.setPowerState.successfulProvider", meta.SuccessfulProvider),
+			attribute.StringSlice("bmc.setPowerState.providersAttempted", meta.ProvidersAttempted))
 	}
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	if err != nil {

--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -146,10 +146,8 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	m.SendStatusMessage("connecting to BMC")
 	err = client.Open(ctx)
 	meta := client.GetMetadata()
-	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
-		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
-		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
-		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
+	span.SetAttributes(attribute.StringSlice("bmc.open.providersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmc.open.successfulOpenConns", meta.SuccessfulOpenConns))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return "", &repository.Error{
@@ -168,10 +166,8 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	ok, err := client.SetBootDevice(ctx, dev, persistent, efiBoot)
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	meta = client.GetMetadata()
-	span.SetAttributes(attribute.String("bmclib.SuccessfulProvider", meta.SuccessfulProvider),
-		attribute.StringSlice("bmclib.ProvidersAttempted", meta.ProvidersAttempted),
-		attribute.StringSlice("bmclib.SuccessfulOpenConns", meta.SuccessfulOpenConns),
-		attribute.StringSlice("bmclib.SuccessfulCloseConns", meta.SuccessfulCloseConns))
+	span.SetAttributes(attribute.String("bmc.setBootDevice.successfulProvider", meta.SuccessfulProvider),
+		attribute.StringSlice("bmc.setBootDevice.ProvidersAttempted", meta.ProvidersAttempted))
 	if err != nil {
 		log.Error(err, "failed to set boot device")
 	} else if !ok {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Tune the open telemetry attributes a bit with regard to metadata returned from BMC calls. 

The metadata from bmclib calls being used for otel attributes
was being overwritten each time it was set. This namespaces the
metadata based on its corresponding bmclib call.
`bmc.<bmclib method name>.<metadata field>`

Also, not all metadata is needed for each bmclib call. Only
pertinent metadata is used when setting an otel attribute.

Finally, it appeared from other attributes being set that having
each field start with a lowercase letter was the pattern. So
this also updates the attributes to follow that pattern.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested locally using https://github.com/equinix-labs/otel-cli 
1. `git clone https://github.com/equinix-labs/otel-cli.git`
2. `cd otel-cli`
3. `docker-compose up`
4. `cd pbnj`
5. `export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317; export OTEL_EXPORTER_OTLP_INSECURE=true`
6. `make run-server`
7. `make evans`
8. make some calls.
9. go to `http://localhost:16686/` and watch the traces come in.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
