### PR TITLE
convert StringSlice attributes to Strings for now

### DIFF
--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -146,8 +146,11 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	m.SendStatusMessage("connecting to BMC")
 	err = client.Open(ctx)
 	meta := client.GetMetadata()
-	span.SetAttributes(attribute.StringSlice("bmc.open.providersAttempted", meta.ProvidersAttempted),
-		attribute.StringSlice("bmc.open.successfulOpenConns", meta.SuccessfulOpenConns))
+	// The following lines and others in the commit that created this comment were changed to use Sprintf
+	// because honeycomb.io didn't yet support StringSlices. Hopefully, dear reader, the world has changed
+	// and you can revert this commit.
+	span.SetAttributes(attribute.String("bmc.open.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)),
+		attribute.String("bmc.open.successfulOpenConns", fmt.Sprintf("%v", meta.SuccessfulOpenConns)))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return "", &repository.Error{
@@ -167,7 +170,7 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	meta = client.GetMetadata()
 	span.SetAttributes(attribute.String("bmc.setBootDevice.successfulProvider", meta.SuccessfulProvider),
-		attribute.StringSlice("bmc.setBootDevice.ProvidersAttempted", meta.ProvidersAttempted))
+		attribute.String("bmc.setBootDevice.ProvidersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)))
 	if err != nil {
 		log.Error(err, "failed to set boot device")
 	} else if !ok {
@@ -252,8 +255,8 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 
 	err = client.Open(ctx)
 	meta := client.GetMetadata()
-	span.SetAttributes(attribute.StringSlice("bmc.open.providersAttempted", meta.ProvidersAttempted),
-		attribute.StringSlice("bmc.open.successfulOpenConns", meta.SuccessfulOpenConns))
+	span.SetAttributes(attribute.String("bmc.open.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)),
+		attribute.String("bmc.open.successfulOpenConns", fmt.Sprintf("%v", meta.SuccessfulOpenConns)))
 
 	if err != nil {
 		span.SetStatus(codes.Error, "connecting to BMC failed: "+err.Error())
@@ -279,7 +282,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	currentPowerState, err := client.GetPowerState(ctx)
 	meta = client.GetMetadata()
 	span.SetAttributes(attribute.String("bmc.getPowerState.successfulProvider", meta.SuccessfulProvider),
-		attribute.StringSlice("bmc.getPowerState.providersAttempted", meta.ProvidersAttempted))
+		attribute.String("bmc.getPowerState.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)))
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get power state: "+err.Error())
 		log.Error(err, "failed to get power state")
@@ -308,7 +311,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 		result = fmt.Sprintf("%v complete", base)
 		meta = client.GetMetadata()
 		span.SetAttributes(attribute.String("bmc.setPowerState.successfulProvider", meta.SuccessfulProvider),
-			attribute.StringSlice("bmc.setPowerState.providersAttempted", meta.ProvidersAttempted))
+			attribute.String("bmc.setPowerState.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)))
 	}
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	if err != nil {


### PR DESCRIPTION
## Description

honeycomb.io doesn't currently support rendering StringSlice attributes.
We'll switch to using strings for now, with the hope that this can some day be reverted.

## Why is this needed

honeycomb.io doesn't currently support StringSlice attributes.

## How Has This Been Tested?

- Build and test with evans

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade