### PR TITLE
Defer the cancel in RPC background tasks:

### DIFF
--- a/grpc/rpc/bmc.go
+++ b/grpc/rpc/bmc.go
@@ -53,10 +53,7 @@ func (b *BmcService) Reset(ctx context.Context, in *v1.ResetRequest) (*v1.ResetR
 			return "", err
 		}
 		taskCtx, cancel := context.WithTimeout(ctx, b.Timeout)
-		// cant defer this cancel because it cancels the context before the func is run
-		// cant have cancel be _ because go vet complains.
-		// TODO(jacobweinstock): maybe move this context withTimeout into the TaskRunner.Execute function
-		_ = cancel
+		defer cancel()
 		return "", t.BMCReset(taskCtx, in.ResetKind.String())
 	}
 	b.TaskRunner.Execute(ctx, "bmc reset", taskID, execFunc)
@@ -92,7 +89,7 @@ func (b *BmcService) CreateUser(ctx context.Context, in *v1.CreateUserRequest) (
 		// a child context. This allows us to correctly plumb otel into the background task.
 		c := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		taskCtx, cancel := context.WithTimeout(c, b.Timeout)
-		_ = cancel
+		defer cancel()
 		return "", t.CreateUser(taskCtx)
 	}
 	b.TaskRunner.Execute(ctx, "creating user", taskID, execFunc)
@@ -128,7 +125,7 @@ func (b *BmcService) UpdateUser(ctx context.Context, in *v1.UpdateUserRequest) (
 		// a child context. This allows us to correctly plumb otel into the background task.
 		c := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		taskCtx, cancel := context.WithTimeout(c, b.Timeout)
-		_ = cancel
+		defer cancel()
 		return "", t.UpdateUser(taskCtx)
 	}
 	b.TaskRunner.Execute(ctx, "updating user", taskID, execFunc)
@@ -162,7 +159,7 @@ func (b *BmcService) DeleteUser(ctx context.Context, in *v1.DeleteUserRequest) (
 		// a child context. This allows us to correctly plumb otel into the background task.
 		c := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		taskCtx, cancel := context.WithTimeout(c, b.Timeout)
-		_ = cancel
+		defer cancel()
 		return "", t.DeleteUser(taskCtx)
 	}
 	b.TaskRunner.Execute(ctx, "deleting user", taskID, execFunc)

--- a/grpc/rpc/machine.go
+++ b/grpc/rpc/machine.go
@@ -53,7 +53,7 @@ func (m *MachineService) BootDevice(ctx context.Context, in *v1.DeviceRequest) (
 		// a child context. This allows us to correctly plumb otel into the background task.
 		c := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		taskCtx, cancel := context.WithTimeout(c, m.Timeout)
-		_ = cancel
+		defer cancel()
 		return mbd.BootDeviceSet(taskCtx, in.BootDevice.String(), in.Persistent, in.EfiBoot)
 	}
 	m.TaskRunner.Execute(ctx, "setting boot device", taskID, execFunc)
@@ -88,7 +88,7 @@ func (m *MachineService) Power(ctx context.Context, in *v1.PowerRequest) (*v1.Po
 		// a child context. This allows us to correctly plumb otel into the background task.
 		c := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
 		taskCtx, cancel := context.WithTimeout(c, m.Timeout)
-		_ = cancel
+		defer cancel()
 		return mp.PowerSet(taskCtx, in.PowerAction.String())
 	}
 	m.TaskRunner.Execute(ctx, "power action: "+in.GetPowerAction().String(), taskID, execFunc)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Not calling cancel is not ideal. It was previously thought that a defer in this context would be called before the function was run. This is not the case.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
