### PR TITLE
Migrate to newer/more maintained jwt library:

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	jwt "github.com/cristalhq/jwt/v3"
-	jwt_helper "github.com/dgrijalva/jwt-go"
 	"github.com/equinix-labs/otel-init-go/otelinit"
+	jwt_helper "github.com/golang-jwt/jwt/v4"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.16
 require (
 	github.com/bmc-toolbox/bmclib v0.4.14-0.20211027184927-2f9a20e0a479
 	github.com/cristalhq/jwt/v3 v3.0.9
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/equinix-labs/otel-init-go v0.0.4
 	github.com/fatih/color v1.7.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
 	github.com/go-test/deep v1.0.7
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
github.com/dgrijalva/jwt-go -> github.com/golang-jwt/jwt/v4
because of CVE-2020-26160. See: https://github.com/advisories/GHSA-w73w-5m7g-f7qc

## Why is this needed

<!--- Link to issue you have raised -->
fixes security advisory. See https://github.com/tinkerbell/pbnj/security/dependabot/go.sum/github.com%2Fdgrijalva%2Fjwt-go/open 

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested using `make run-server` and `make evans`. Followed https://github.com/tinkerbell/pbnj/blob/main/docs/Authorization.md to test auth.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
