### PR TITLE
Try Redfish first when communicating with a BMC:

### DIFF
--- a/grpc/oob/bmc/bmc.go
+++ b/grpc/oob/bmc/bmc.go
@@ -229,6 +229,7 @@ func (m Action) BMCReset(ctx context.Context, rType string) (err error) {
 	}
 	m.SendStatusMessage("working on bmc reset")
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
+	client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 
 	lookup := map[string]string{
 		v1.ResetKind_RESET_KIND_COLD.String(): "cold",

--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -142,6 +142,7 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	m.SendStatusMessage(msg)
 
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
+	client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 
 	m.SendStatusMessage("connecting to BMC")
 	err = client.Open(ctx)
@@ -252,6 +253,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	m.SendStatusMessage(msg)
 
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
+	client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 
 	err = client.Open(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Ipmitool is the older of the two protocols between itself and Redfish. Many machines would benefit and possibly be more reliable if Redfish was tried first.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
