### PR TITLE
Revert "convert StringSlice attributes to Strings for now"

### DIFF
--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -147,11 +147,8 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	m.SendStatusMessage("connecting to BMC")
 	err = client.Open(ctx)
 	meta := client.GetMetadata()
-	// The following lines and others in the commit that created this comment were changed to use Sprintf
-	// because honeycomb.io didn't yet support StringSlices. Hopefully, dear reader, the world has changed
-	// and you can revert this commit.
-	span.SetAttributes(attribute.String("bmc.open.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)),
-		attribute.String("bmc.open.successfulOpenConns", fmt.Sprintf("%v", meta.SuccessfulOpenConns)))
+	span.SetAttributes(attribute.StringSlice("bmc.open.providersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmc.open.successfulOpenConns", meta.SuccessfulOpenConns))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return "", &repository.Error{
@@ -171,7 +168,7 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	meta = client.GetMetadata()
 	span.SetAttributes(attribute.String("bmc.setBootDevice.successfulProvider", meta.SuccessfulProvider),
-		attribute.String("bmc.setBootDevice.ProvidersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)))
+		attribute.StringSlice("bmc.setBootDevice.ProvidersAttempted", meta.ProvidersAttempted))
 	if err != nil {
 		log.Error(err, "failed to set boot device")
 	} else if !ok {
@@ -266,8 +263,8 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 		}
 	}
 	meta := client.GetMetadata()
-	span.SetAttributes(attribute.String("bmc.open.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)),
-		attribute.String("bmc.open.successfulOpenConns", fmt.Sprintf("%v", meta.SuccessfulOpenConns)))
+	span.SetAttributes(attribute.StringSlice("bmc.open.providersAttempted", meta.ProvidersAttempted),
+		attribute.StringSlice("bmc.open.successfulOpenConns", meta.SuccessfulOpenConns))
 
 	log := m.Log.WithValues("action", action, "host", host, "user", user)
 
@@ -283,7 +280,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	currentPowerState, err := client.GetPowerState(ctx)
 	meta = client.GetMetadata()
 	span.SetAttributes(attribute.String("bmc.getPowerState.successfulProvider", meta.SuccessfulProvider),
-		attribute.String("bmc.getPowerState.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)))
+		attribute.StringSlice("bmc.getPowerState.providersAttempted", meta.ProvidersAttempted))
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get power state: "+err.Error())
 		log.Error(err, "failed to get power state")
@@ -312,7 +309,7 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 		result = fmt.Sprintf("%v complete", base)
 		meta = client.GetMetadata()
 		span.SetAttributes(attribute.String("bmc.setPowerState.successfulProvider", meta.SuccessfulProvider),
-			attribute.String("bmc.setPowerState.providersAttempted", fmt.Sprintf("%v", meta.ProvidersAttempted)))
+			attribute.StringSlice("bmc.setPowerState.providersAttempted", meta.ProvidersAttempted))
 	}
 	log = m.Log.WithValues(logMetadata(client.GetMetadata())...)
 	if err != nil {


### PR DESCRIPTION
## Description

Dear reader, the world has changed.
https://github.com/honeycombio/husky/pull/17 has been merged.

## Why is this needed

Reverts #109 / 3581292 as the underlying issue has been fixed for honeycomb.

## How Has This Been Tested?
- [x] Local testing pointed at a honeycomb sandbox

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
