### PR TITLE
Revert "Try Redfish first when communicating with a BMC:"

### DIFF
--- a/grpc/oob/bmc/bmc.go
+++ b/grpc/oob/bmc/bmc.go
@@ -243,7 +243,6 @@ func (m Action) BMCReset(ctx context.Context, rType string) (err error) {
 	}
 	m.SendStatusMessage("working on bmc reset")
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
-	client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 
 	lookup := map[string]string{
 		v1.ResetKind_RESET_KIND_COLD.String(): "cold",

--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -142,7 +142,6 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	m.SendStatusMessage(msg)
 
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
-	client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 
 	m.SendStatusMessage("connecting to BMC")
 	err = client.Open(ctx)
@@ -250,7 +249,6 @@ func (m Action) PowerSet(ctx context.Context, action string) (result string, err
 	m.SendStatusMessage(msg)
 
 	client := bmclib.NewClient(host, "623", user, password, bmclib.WithLogger(m.Log))
-	client.Registry.Drivers = client.Registry.PreferDriver("gofish")
 
 	err = client.Open(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

This reverts commit 32e7bbd9774f598c9e86b6729fca30b10bd18ee2.

Some redfish implementations are buggy and while being compatible
they incorrectly report their power status (ASRRs E3C246D4I-NL)
until we're a bit more confident that various redfish implementation
behave as expected lets go with IPMI being attempted first.

https://github.com/bmc-toolbox/bmclib/blob/master/client.go#L104

If theres a pressing need to have redfish attempted first
the change can be pushed down into bmclib to ignore redfish on the ASRRs
although this does not seem like an ideal solution at the moment.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

This should have no negative impact on existing users.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
