### PR TITLE
Add additional OTEL tracing into grpc/oob/bmc/bmc.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.9 as builder
+FROM golang:1.17.11 as builder
 
 WORKDIR /code
 COPY go.mod go.sum /code/

--- a/grpc/oob/bmc/bmc.go
+++ b/grpc/oob/bmc/bmc.go
@@ -187,8 +187,7 @@ func (m Action) CreateUser(ctx context.Context) error {
 		return err
 	}
 
-	err = oob.CreateUser(ctx, actions)
-	if err != nil {
+	if err = oob.CreateUser(ctx, actions); err != nil {
 		m.noteError(fmt.Sprintf("error %s: %v", status, err), span)
 		return err
 	}
@@ -222,8 +221,7 @@ func (m Action) UpdateUser(ctx context.Context) error {
 		return err
 	}
 
-	err = oob.UpdateUser(ctx, actions)
-	if err != nil {
+	if err = oob.UpdateUser(ctx, actions); err != nil {
 		m.noteError(fmt.Sprintf("error %s: %v", status, err), span)
 		return err
 	}
@@ -257,8 +255,7 @@ func (m Action) DeleteUser(ctx context.Context) error {
 		return err
 	}
 
-	err = oob.DeleteUser(ctx, actions)
-	if err != nil {
+	if err = oob.DeleteUser(ctx, actions); err != nil {
 		m.noteError(fmt.Sprintf("error %s: %v", status, err), span)
 		return err
 	}

--- a/grpc/rpc/bmc.go
+++ b/grpc/rpc/bmc.go
@@ -51,7 +51,10 @@ func (b *BmcService) Reset(ctx context.Context, in *v1.ResetRequest) (*v1.ResetR
 		if err != nil {
 			return "", err
 		}
-		taskCtx, cancel := context.WithTimeout(ctx, b.Timeout)
+		// Because this is a background task, we want to pass through the span context, but not be
+		// a child context. This allows us to correctly plumb otel into the background task.
+		c := trace.ContextWithSpanContext(context.Background(), trace.SpanContextFromContext(ctx))
+		taskCtx, cancel := context.WithTimeout(c, b.Timeout)
 		defer cancel()
 		return "", t.BMCReset(taskCtx, in.ResetKind.String())
 	}


### PR DESCRIPTION
## Description

Create client.Thing spans in bmc.go functions that do the heavy lifting.

## Why is this needed

Fixes: #122 

## How Has This Been Tested?

- [x] Manually

## How are existing users impacted? What migration steps/scripts do we need?

If you're sending otel spans, now you'll send more.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
