### PR TITLE
Fixes ipmitool init error Failed to initialize the OEM info dictionary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,14 @@ RUN apk add --update --upgrade --no-cache --virtual build-deps \
     && git clone -b master ${IPMITOOL_REPO}
 
 WORKDIR /tmp/ipmitool
+
+#
+# cherry-pick'ed 1edb0e27e44196d1ebe449aba0b9be22d376bcb6
+# to fix https://github.com/ipmitool/ipmitool/issues/377
+#
 RUN git checkout ${IPMITOOL_COMMIT} \
+    && git config --global user.email "github.ci@doesnot.existorg" \
+    && git cherry-pick 1edb0e27e44196d1ebe449aba0b9be22d376bcb6 \
     && ./bootstrap \
     && ./configure \
         --prefix=/usr/local \


### PR DESCRIPTION
## Description

Its silly that we missed this in the original PR incrementing the ipmitool version, but here we go.

ipmitool fails to start up with the error `ipmitool init error Failed to initialize the OEM info dictionary`,
this pulls in the fix referenced in the linked issue.

https://github.com/ipmitool/ipmitool/issues/377

## Why is this needed


Fixes: #

## How Has This Been Tested?
 - Tested locally and on a few machines


## How are existing users impacted? What migration steps/scripts do we need?
No impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
