### PR TITLE
Ensure a 120 second 'provider timeout' with each bmclib client

### DIFF
--- a/grpc/oob/bmc/bmc.go
+++ b/grpc/oob/bmc/bmc.go
@@ -3,6 +3,7 @@ package bmc
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
 	"github.com/bmc-toolbox/bmclib/v2/bmc"
@@ -310,6 +311,9 @@ func (m Action) BMCReset(ctx context.Context, rType string) (err error) {
 	span.SetAttributes(attribute.String("bmc.host", host), attribute.String("bmc.username", user))
 	m.SendStatusMessage("working on bmc reset")
 
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
 	opts := []bmclib.Option{
 		bmclib.WithLogger(m.Log),
 		bmclib.WithPerProviderTimeout(common.BMCTimeoutFromCtx(ctx)),
@@ -380,6 +384,9 @@ func (m Action) DeactivateSOL(ctx context.Context) error {
 	}
 	span.SetAttributes(attribute.String("bmc.host", host), attribute.String("bmc.username", user))
 	m.SendStatusMessage("working on SOL session deactivation")
+
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
 
 	opts := []bmclib.Option{
 		bmclib.WithLogger(m.Log),

--- a/grpc/oob/bmc/users_bmclibv2.go
+++ b/grpc/oob/bmc/users_bmclibv2.go
@@ -3,6 +3,7 @@ package bmc
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
 	"github.com/go-logr/logr"
@@ -32,6 +33,9 @@ type bmclibv2UserManagement struct {
 // Connect sets up the BMC client connection.
 func (b *bmclibv2UserManagement) Connect(ctx context.Context) error {
 	var errMsg repository.Error
+
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
 
 	opts := []bmclib.Option{
 		bmclib.WithLogger(b.log),

--- a/grpc/oob/diagnostic/clearsel.go
+++ b/grpc/oob/diagnostic/clearsel.go
@@ -3,6 +3,7 @@ package diagnostic
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
@@ -54,6 +55,9 @@ func (m Action) ClearSystemEventLog(ctx context.Context) (result string, err err
 		return result, parseErr
 	}
 	span.SetAttributes(attribute.String("bmc.host", host), attribute.String("bmc.username", user))
+
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
 
 	opts := []bmclib.Option{
 		bmclib.WithLogger(m.Log),

--- a/grpc/oob/diagnostic/nmi.go
+++ b/grpc/oob/diagnostic/nmi.go
@@ -3,6 +3,7 @@ package diagnostic
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -49,6 +50,9 @@ func (m Action) SendNMI(ctx context.Context) error {
 		return parseErr
 	}
 	span.SetAttributes(attribute.String("bmc.host", host), attribute.String("bmc.username", user))
+
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
 
 	opts := []bmclib.Option{
 		bmclib.WithLogger(m.Log),

--- a/grpc/oob/diagnostic/screenshot.go
+++ b/grpc/oob/diagnostic/screenshot.go
@@ -3,6 +3,7 @@ package diagnostic
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
 	"github.com/bmc-toolbox/bmclib/v2/bmc"
@@ -55,6 +56,9 @@ func (m Action) GetScreenshot(ctx context.Context) (image []byte, filetype strin
 		return nil, "", parseErr
 	}
 	span.SetAttributes(attribute.String("bmc.host", host), attribute.String("bmc.username", user))
+
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
 
 	opts := []bmclib.Option{
 		bmclib.WithLogger(m.Log),

--- a/grpc/oob/machine/machine.go
+++ b/grpc/oob/machine/machine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
 	"github.com/bmc-toolbox/bmclib/v2/bmc"
@@ -148,6 +149,9 @@ func (m Action) BootDeviceSet(ctx context.Context, device string, persistent, ef
 	base := "setting boot device: " + m.BootDeviceRequest.GetBootDevice().String()
 	msg := "working on " + base
 	m.SendStatusMessage(msg)
+
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
 
 	opts := []bmclib.Option{
 		bmclib.WithLogger(m.Log),


### PR DESCRIPTION
## Description

It has recently been discovered that bmclib's handling of timeouts, combined with the multiple providers leads to a number of failed actions initiated by pbnj.    This change increases the timeout to 120 seconds which is clearly far longer than a timeout needs to be in this instance.

## Why is this needed

While troubleshooting this issue it was discovered that bmclib can take 20-30 *seconds* performing actions via redfish.   This timeout increase is meant as a bandaid fix while we investigate the performance issue(s) in bmclib.